### PR TITLE
fix: Fixes Proxy forward when expected Nuxt port is taken

### DIFF
--- a/docs/api/configuration.md
+++ b/docs/api/configuration.md
@@ -69,11 +69,11 @@ DIRECTUS_ADMIN_TOKEN=your-admin-token-here
 
 ### `devProxy`
 
-- **Type:** `boolean | { enabled?: boolean, path?: string }`
-- **Default:** `{ enabled: true, path: '/directus' }` in dev mode
+- **Type:** `boolean | { enabled?: boolean, path?: string, wsPath?: string }`
+- **Default:** `{ enabled: true, path: '/directus', wsPath: '/directus-ws' }` in dev mode
 - **Default:** `false` in production
 
-Development proxy configuration. When enabled, creates a proxy that forwards requests to your Directus instance, eliminating CORS issues.
+Development proxy configuration. When enabled, creates a proxy that forwards requests to your Directus instance, eliminating CORS issues and supporting dynamic ports.
 
 ```typescript
 export default defineNuxtConfig({
@@ -84,16 +84,18 @@ export default defineNuxtConfig({
     // Or detailed configuration
     devProxy: {
       enabled: true,
-      path: '/directus', // Proxy mount path
+      path: '/directus',      // HTTP proxy mount path
+      wsPath: '/directus-ws', // WebSocket proxy path (optional)
     },
   },
 })
 ```
 
 **How it works:**
-- In development: Requests to `http://localhost:3000/directus` forward to your Directus URL
+- In development: Requests automatically route through the proxy using the current port
+- Supports Nuxt's dynamic port changes (e.g., port 3000 → 3001)
 - In production: Direct connection to Directus URL
-- WebSocket proxy available at `${path}-ws` for realtime features
+- WebSocket proxy available at `wsPath` for realtime features
 
 **Disable proxy:**
 ```typescript
@@ -374,6 +376,7 @@ export default defineNuxtConfig({
     devProxy: {
       enabled: true,
       path: '/directus',
+      wsPath: '/directus-ws',
     },
     devtools: true,
     visualEditor: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -285,9 +285,6 @@ export default defineNuxtModule<ModuleOptions>({
         handler: resolver.resolve('./runtime/server/routes/directus'),
       })
 
-      // Don't overwrite options.url - let composables construct it dynamically
-      // This ensures the correct port is used when Nuxt picks a dynamic port
-
       // Store normalized devProxy config for runtime use
       options.devProxy = {
         enabled: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,8 +19,8 @@ export interface ModuleOptions {
    * Development proxy configuration
    * When enabled, creates a proxy at /directus that forwards to your Directus URL
    * This solves CORS and cookie issues in development
-   * @default { enabled: true, path: '/directus' } in dev mode
-   * @type boolean | { enabled?: boolean, path?: string }
+   * @default { enabled: true, path: '/directus', wsPath: '/directus-ws' } in dev mode
+   * @type boolean | { enabled?: boolean, path?: string, wsPath?: string }
    */
   devProxy?: boolean | {
     /**
@@ -33,6 +33,11 @@ export interface ModuleOptions {
      * @default '/directus'
      */
     path?: string
+    /**
+     * WebSocket proxy path (for realtime connections)
+     * @default '/directus-ws'
+     */
+    wsPath?: string
   }
 
   /**
@@ -191,6 +196,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Default values
     const devProxyEnabled = devProxyConfig.enabled ?? nuxtApp.options.dev
     const devProxyPath = devProxyConfig.path ?? '/directus'
+    const wsProxyPath = devProxyConfig.wsPath ?? `${devProxyPath}-ws`
 
     // Store the original URL for type generation and server-side use
     const directusUrl = options.url
@@ -200,13 +206,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Set up development proxy if enabled and in dev mode
     if (devProxyEnabled && nuxtApp.options.dev) {
-      // Use a separate route for WebSocket proxy to avoid conflicts with the HTTP handler
-      const wsProxyPath = `${devProxyPath}-ws`
-
       logger.info(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
       logger.info(`🔄 Directus Development Proxy Enabled`)
       logger.info(`   Proxy path: ${devProxyPath}`)
       logger.info(`   WebSocket proxy path: ${wsProxyPath}`)
+      logger.info(`   Forwarding to: ${directusUrl}`)
       logger.info(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`)
 
       // Configure WebSocket proxy for realtime support (WebSocket only)
@@ -288,10 +292,8 @@ export default defineNuxtModule<ModuleOptions>({
       options.devProxy = {
         enabled: true,
         path: devProxyPath,
+        wsPath: wsProxyPath,
       }
-
-      // Store the WebSocket proxy path pattern for client use
-      ;(options as any).wsProxyPath = wsProxyPath
     }
     else if (!nuxtApp.options.dev) {
       logger.info(`🌐 Production mode: Connecting directly to ${directusUrl}`)

--- a/src/runtime/composables/directus.ts
+++ b/src/runtime/composables/directus.ts
@@ -9,7 +9,30 @@ export function useDirectusPreview(): Ref<boolean> {
 }
 
 export function useDirectusUrl(path = ''): string {
-  return useUrl(useRuntimeConfig().public.directus.url, path)
+  const config = useRuntimeConfig()
+
+  const devProxy = config.public.directus.devProxy
+  const devProxyEnabled = typeof devProxy === 'object' ? devProxy.enabled !== false : devProxy !== false
+
+  // When devProxy is enabled, use current origin + proxy path
+  if (devProxyEnabled) {
+    const proxyPath = typeof devProxy === 'object' && devProxy.path ? devProxy.path : '/directus'
+
+    if (import.meta.client) {
+      return useUrl(`${window.location.origin}${proxyPath}`, path)
+    }
+    else {
+      // Server-side: get host from request headers if available
+      const requestHeaders = useRequestHeaders(['host'])
+      if (requestHeaders?.host) {
+        const protocol = import.meta.dev ? 'http' : 'https'
+        return useUrl(`${protocol}://${requestHeaders.host}${proxyPath}`, path)
+      }
+    }
+  }
+
+  // Fallback to configured URL
+  return useUrl(config.public.directus.url, path)
 }
 
 function createDirectusClient() {
@@ -21,10 +44,13 @@ function createDirectusClient() {
 
   // Create custom fetch that forwards cookies during SSR
   const customFetch: typeof fetch = async (url, options) => {
+    // Convert URL to string for $fetch
+    const urlString = typeof url === 'string' ? url : url.toString()
+
     // During SSR, forward cookies from the incoming request
     if (import.meta.server && requestHeaders?.cookie) {
-      return globalThis.$fetch(url, {
-        ...options,
+      return globalThis.$fetch(urlString, {
+        ...options as any,
         headers: {
           ...options?.headers,
           cookie: requestHeaders.cookie,
@@ -33,7 +59,7 @@ function createDirectusClient() {
     }
 
     // On client, use regular fetch with credentials
-    return globalThis.$fetch(url, { ...options, credentials: 'include' })
+    return globalThis.$fetch(urlString, { ...options as any, credentials: 'include' })
   }
 
   const baseUrl = useDirectusUrl()


### PR DESCRIPTION
Fixes the issue where Nuxt will dynamically allocate a port if 3000 is taken, the proxy will now use the same port that nuxt will automatically assing