### PR TITLE
feat: auto-import all functions from @directus/sdk dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,35 +70,42 @@ For cross-domain setups (e.g., `app.example.com` ↔ `api.example.com`), see the
 
 ## Development
 
-> [!IMPORTANT] The playground uses [directus-template-cli](https://github.com/directus-labs/directus-template-cli?tab=readme-ov-file#applying-a-template) `cms` template.
-> Apply the template with `npx directus-template-cli@latest apply` and follow the interactive prompts.
+This project uses [pnpm](https://pnpm.io) via [corepack](https://nodejs.org/api/corepack.html). Run `corepack enable` once to activate it, then pnpm is available automatically at the version pinned in `package.json`.
+
+> [!IMPORTANT]
+> The playground uses the [directus-template-cli](https://github.com/directus-labs/directus-template-cli?tab=readme-ov-file#applying-a-template) `cms` template.
+> Apply it with `npx directus-template-cli@latest apply` and follow the interactive prompts.
 
 ```bash
 # Install dependencies
-bun install
+pnpm install
 
 # Add DIRECTUS_ADMIN_TOKEN to playground .env (don't forget to update your token)
 cp ./playground/.env.example ./playground/.env
 
 # Generate type stubs
-bun run dev:prepare
+pnpm dev:prepare
 
 # Develop with the playground
-bun run dev
+pnpm dev
 
 # Build the playground
-bun run dev:build
+pnpm dev:build
 
 # Run ESLint
-bun run lint
+pnpm lint
 
 # Run Vitest
-bun run test
-bun run test:watch
+pnpm test
+pnpm test:watch
 
 # Release new version
-bun run release
+pnpm release
 ```
+
+## Contributing
+
+Contributions are welcome! Please target the **`next`** branch for new features and fixes — `main` is reserved for stable releases and hotfixes only. See [RELEASING.md](./RELEASING.md) for details on the release process.
 
 <!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/nuxt-directus-sdk/latest.svg?style=flat&colorA=18181B&colorB=28CF8D

--- a/docs/api/composables/index.md
+++ b/docs/api/composables/index.md
@@ -56,20 +56,28 @@ const created = await directus.request(createItem('articles', {
 
 ### Functions excluded from auto-import
 
-A small number of SDK functions are intentionally **not** auto-imported. Most are wrapped by this module's own composables — using them directly bypasses features like SSR cookie forwarding or devProxy handling, which typically isn't what you want. They can still be imported manually from `@directus/sdk` when you have a specific reason.
+A small number of SDK functions are intentionally not auto-imported — either because this module provides a composable wrapper, or because the function is an internal SDK detail. All of them can still be imported manually from `@directus/sdk` when you have a specific reason.
 
-| Function | Why it's excluded |
-| --- | --- |
-| `createDirectus()` | Use [`useDirectus()`](#directus-client-composables) — returns a fully-configured singleton with auth, rest, realtime, and SSR cookie forwarding already attached. |
-| `rest()` | Transport plugin; already attached by `useDirectus()`. |
-| `realtime()` | Realtime/WebSocket plugin; already attached by `useDirectus()`. |
-| `authentication()` | Auth plugin; already attached by `useDirectus()`. |
-| `staticToken()` | Static-token auth plugin. The module uses this internally via the `adminToken` config for type generation and server-only tasks. If you need a one-off authenticated client (e.g. a server handler calling Directus with a service token), import it manually alongside `createDirectus()` and `rest()`. |
-| `auth()` | Low-level auth handler. Use the auth composables ([`useDirectusAuth`](#authentication-composables), etc.) for normal login/logout/refresh flows. Import manually only if you're building a custom auth pipeline outside the module. |
-| `getAuthEndpoint()` | Auth endpoint path helper (e.g. resolves the correct `/auth/login` route for a flow). Only useful if you're hand-rolling auth requests outside the module's composables — rare. |
-| `memoryStorage()` | Storage primitive — use [`useDirectusStorage()`](#storage-composables) instead. |
-| `graphql()` | This module does not wrap or support GraphQL. If you need it, import consciously so expectations are explicit. |
-| `readGraphqlSdl()` | GraphQL-specific; kept as a manual import for the same reason. |
+| Category | Function | Use instead |
+| --- | --- | --- |
+| Client setup | `createDirectus()` | Use [`useDirectus()`](#directus-client-composables) — pre-configured with `auth()`, `rest()`, `realtime()`, and SSR cookie forwarding. |
+| Client setup | `authentication()` | Already configured by `useDirectus()`. |
+| Client setup | `rest()` | Already configured by `useDirectus()`. |
+| Client setup | `realtime()` | Already configured by `useDirectus()`. |
+| Client setup | `staticToken()` | Used internally for `adminToken`. Import manually if you need a one-off static-token client alongside `createDirectus()`. |
+| Auth | `auth()` | Low-level realtime auth handler. Use [`useDirectusAuth()`](#authentication-composables) for normal flows. |
+| Auth | `getAuthEndpoint()` | Internal SDK auth routing helper. |
+| Auth | `acceptUserInvite()` | Use [`useDirectusAuth().acceptUserInvite()`](#authentication-composables). |
+| Auth | `createUser()` | Use [`useDirectusAuth().createUser()`](#authentication-composables). |
+| Auth | `inviteUser()` | Use [`useDirectusAuth().inviteUser()`](#authentication-composables). |
+| Auth | `passwordRequest()` | Use [`useDirectusAuth().passwordRequest()`](#authentication-composables). |
+| Auth | `passwordReset()` | Use [`useDirectusAuth().passwordReset()`](#authentication-composables). |
+| Auth | `readMe()` | Use [`useDirectusAuth().readMe()`](#authentication-composables) — manages shared user state. |
+| Auth | `updateMe()` | Use [`useDirectusAuth().updateMe()`](#authentication-composables) — manages shared user state. |
+| Files | `uploadFiles()` | Use [`uploadDirectusFiles()`](#file-composables) — handles `FormData` construction. |
+| Storage | `memoryStorage()` | Use [`useDirectusStorage()`](#storage-composables). |
+| GraphQL | `graphql()` | Not supported by this module. Import manually if needed. |
+| GraphQL | `readGraphqlSdl()` | Not supported by this module. Import manually if needed. |
 
 If you need one of these, import it directly:
 

--- a/docs/api/composables/index.md
+++ b/docs/api/composables/index.md
@@ -30,21 +30,7 @@ const url = getDirectusFileUrl(file, {
 
 ## Auto-Imported Directus SDK Functions
 
-The module auto-imports commonly used Directus SDK functions:
-
-|Category|AutoImported Functions|
-|---|---|
-| <Badge>Items</Badge> | `createItem()`, `createItems()`, `readItem()`, `readItems()`, `updateItem()`, `updateItems()`, `deleteItem()`, `deleteItems()` |
-| <Badge>Singletons</Badge> | `readSingleton()`, `updateSingleton()` |
-| <Badge>Files</Badge> | `uploadFiles()`, `readFile()`, `readFiles()`, `updateFile()`, `updateFiles()`, `deleteFile()`, `deleteFiles()` |
-| <Badge>Users</Badge> | `createUser()`, `createUsers()`, `readMe()`, `readUser()`, `readUsers()`, `updateMe()`, `updateUser()`, `updateUsers()`, `deleteUser()`, `deleteUsers()` |
-| <Badge>Collections</Badge> | `createCollection()`, `readCollection()`, `readCollections()`, `updateCollection()`, `deleteCollection()` |
-| <Badge>Fields</Badge> | `createField()`, `readField()`, `readFields()`, `readFieldsByCollection()`, `updateField()`, `deleteField()` |
-| <Badge>Folders</Badge> | `readFolder()`, `readFolders()`, `updateFolder()`, `updateFolders()` |
-| <Badge>Comments</Badge> | `createComment()`, `readComment()`, `updateComment()`, `deleteComment()` |
-| <Badge>Activities</Badge> | `readActivity()`, `readActivities()` |
-| <Badge>Auth</Badge> | `readProviders()` |
-| <Badge>Utilities</Badge> | `aggregate()`, `generateUid()`, `importFile()`, `withToken()` |
+The module auto-imports every function exported by `@directus/sdk` — including any new ones added in future SDK releases — so you can call them directly without an `import` statement. The module reads the SDK's exports at build time, so whichever version of `@directus/sdk` you have installed, those functions are what you get.
 
 **Usage:**
 
@@ -67,6 +53,57 @@ const created = await directus.request(createItem('articles', {
   status: 'draft',
 }))
 ```
+
+### Functions excluded from auto-import
+
+A small number of SDK functions are intentionally **not** auto-imported. Most are wrapped by this module's own composables — using them directly bypasses features like SSR cookie forwarding or devProxy handling, which typically isn't what you want. They can still be imported manually from `@directus/sdk` when you have a specific reason.
+
+| Function | Why it's excluded |
+| --- | --- |
+| `createDirectus()` | Use [`useDirectus()`](#directus-client-composables) — returns a fully-configured singleton with auth, rest, realtime, and SSR cookie forwarding already attached. |
+| `rest()` | Transport plugin; already attached by `useDirectus()`. |
+| `realtime()` | Realtime/WebSocket plugin; already attached by `useDirectus()`. |
+| `authentication()` | Auth plugin; already attached by `useDirectus()`. |
+| `staticToken()` | Static-token auth plugin. The module uses this internally via the `adminToken` config for type generation and server-only tasks. If you need a one-off authenticated client (e.g. a server handler calling Directus with a service token), import it manually alongside `createDirectus()` and `rest()`. |
+| `auth()` | Low-level auth handler. Use the auth composables ([`useDirectusAuth`](#authentication-composables), etc.) for normal login/logout/refresh flows. Import manually only if you're building a custom auth pipeline outside the module. |
+| `getAuthEndpoint()` | Auth endpoint path helper (e.g. resolves the correct `/auth/login` route for a flow). Only useful if you're hand-rolling auth requests outside the module's composables — rare. |
+| `memoryStorage()` | Storage primitive — use [`useDirectusStorage()`](#storage-composables) instead. |
+| `graphql()` | This module does not wrap or support GraphQL. If you need it, import consciously so expectations are explicit. |
+| `readGraphqlSdl()` | GraphQL-specific; kept as a manual import for the same reason. |
+
+If you need one of these, import it directly:
+
+```typescript
+import { createDirectus, graphql, rest } from '@directus/sdk'
+```
+
+### Disabling or customising auto-imports
+
+You can turn auto-imports off or narrow the list via the [`autoImportSdk`](/api/configuration/module#autoimportsdk) option in your Nuxt config.
+
+**Disable entirely:**
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    autoImportSdk: false,
+  },
+})
+```
+
+**Exclude specific functions** — useful if a name collides with something else in your app:
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    autoImportSdk: {
+      exclude: ['aggregate', 'customEndpoint'],
+    },
+  },
+})
+```
+
+Your `exclude` is additive: the module's built-in exclusions still apply, and you don't need to repeat them.
 
 ## Authentication Composables
 <!--@include: ./auth.md{7,}-->

--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -379,6 +379,41 @@ interface DirectusUsers {
 - Directus system collections (e.g., `DirectusUsers`, `DirectusFiles`) are NOT prefixed
 - All type references are updated to use the prefixed names
 
+### SDK Auto-Imports
+
+#### `autoImportSdk`
+
+- **Type:** `boolean | { exclude?: string[] }`
+- **Default:** `true`
+
+Controls whether the module auto-imports functions from `@directus/sdk`. By default every SDK function is auto-imported (minus a small list the module wraps or explicitly doesn't support — see [Composables > Auto-Imported Directus SDK Functions](/api/composables/#auto-imported-directus-sdk-functions)).
+
+**Disable entirely** — you'll need to `import { ... } from '@directus/sdk'` wherever you use them:
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    autoImportSdk: false,
+  },
+})
+```
+
+**Exclude specific functions** — useful if an SDK function name collides with something else in your app:
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    autoImportSdk: {
+      exclude: ['aggregate', 'customEndpoint'],
+    },
+  },
+})
+```
+
+Your `exclude` list is added to the module's built-in exclusions; you don't need to repeat `createDirectus`, `rest`, etc.
+
+Tree-shaking means disabling auto-imports has no bundle-size benefit for end users — unused SDK functions don't ship regardless. The option exists for collisions and for teams that prefer explicit imports.
+
 ### Authentication Options
 
 #### `auth`

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,6 +2,7 @@ import type { Query } from '@directus/sdk'
 import type { ImageModifiers, ImageProviders } from '@nuxt/image'
 import type { InlinePreset } from 'unimport'
 
+import * as directusSdk from '@directus/sdk'
 import { addComponentsDir, addImportsDir, addImportsSources, addPlugin, addRouteMiddleware, addServerHandler, addTypeTemplate, createResolver, defineNuxtModule, hasNuxtModule, installModule, tryResolveModule, useLogger } from '@nuxt/kit'
 import { colors } from 'consola/utils'
 import { defu } from 'defu'
@@ -176,6 +177,27 @@ export interface ModuleOptions {
      */
     prefix?: string
   }
+
+  /**
+   * Auto-import functions from `@directus/sdk`.
+   *
+   * - `true` (default) — auto-imports every SDK function except those wrapped by
+   *   this module (e.g. `createDirectus`, `rest`, `authentication`) or explicitly
+   *   unsupported (e.g. `graphql`, `readGraphqlSdl`).
+   * - `false` — disables auto-imports entirely. You import from `@directus/sdk`
+   *   manually wherever you use SDK functions.
+   * - `{ exclude: [...] }` — auto-imports with additional functions excluded.
+   *   Useful if an SDK function name collides with something else in your app.
+   *
+   * @default true
+   */
+  autoImportSdk?: boolean | {
+    /**
+     * Additional SDK function names to exclude from auto-import.
+     * Added on top of the module's built-in exclusions.
+     */
+    exclude?: string[]
+  }
 }
 
 const configKey = 'directus'
@@ -201,6 +223,7 @@ export default defineNuxtModule<ModuleOptions>({
       enabled: true,
       prefix: '',
     },
+    autoImportSdk: true,
     auth: {
       enabled: true,
       enableGlobalAuthMiddleware: false,
@@ -413,72 +436,64 @@ export default defineNuxtModule<ModuleOptions>({
     // Add composables
     addImportsDir(resolver.resolve('./runtime/composables'))
 
-    const directusSdkImports: InlinePreset = {
-      from: '@directus/sdk',
-      imports: [
-        'aggregate',
-        'generateUid',
-        'createComment',
-        'updateComment',
-        'deleteComment',
-        'createField',
-        'createItem',
-        'createItems',
-        'deleteField',
-        'deleteFile',
-        'deleteFiles',
-        'readActivities',
-        'readActivity',
-        'deleteItem',
-        'deleteItems',
-        'deleteUser',
-        'deleteUsers',
-        'importFile',
-        'readCollection',
-        'readCollections',
-        'createCollection',
-        'updateCollection',
-        'deleteCollection',
-        'readField',
-        'readFieldsByCollection',
-        'readFields',
-        'readFile',
-        'readFiles',
-        'readItem',
-        'readItems',
-        'readSingleton',
-        'readMe',
-        'createUser',
-        'createUsers',
-        'readUser',
-        'readUsers',
-        'readProviders',
-        'readFolder',
-        'readFolders',
-        'uploadFiles',
-        'updateField',
-        'updateFile',
-        'updateFiles',
-        'updateFolder',
-        'updateFolders',
-        'updateItem',
-        'updateItems',
-        'updateSingleton',
-        'updateMe',
-        'updateUser',
-        'updateUsers',
-        'withToken',
-      ],
-    }
+    // Auto-import every function @directus/sdk exports, except for the
+    // following which the module either wraps, provides a composable for,
+    // or explicitly does not support. Users can still import them manually
+    // from '@directus/sdk' when they have a deliberate reason to.
+    //
+    // Keep MANUAL_IMPORT_ONLY in sync with docs/api/composables/index.md.
+    const MANUAL_IMPORT_ONLY = new Set([
+      // Client construction — useDirectus() returns a fully-configured
+      // singleton with auth, rest, realtime, and SSR cookie forwarding.
+      'createDirectus',
+      'rest',
+      'realtime',
+      'staticToken',
+      'authentication',
+      // Auth internals — use the auth composables (useDirectusAuth, etc.)
+      'auth',
+      'getAuthEndpoint',
+      // Storage primitive — use useDirectusStorage()
+      'memoryStorage',
+      // GraphQL — the module does not wrap or support GraphQL. Imported
+      // manually to keep users' expectations explicit about what this
+      // module covers.
+      'graphql',
+      'readGraphqlSdl',
+    ])
 
-    addImportsSources(directusSdkImports)
+    // autoImportSdk=false disables auto-imports entirely; the { exclude }
+    // shape adds user-provided names on top of the built-in exclusions.
+    const autoImportSdk = options.autoImportSdk ?? true
+    const userExclude = new Set(
+      typeof autoImportSdk === 'object' && autoImportSdk?.exclude
+        ? autoImportSdk.exclude
+        : [],
+    )
+
+    const directusSdkImports: InlinePreset | null = autoImportSdk === false
+      ? null
+      : {
+          from: '@directus/sdk',
+          imports: Object.keys(directusSdk).filter(name =>
+            typeof (directusSdk as Record<string, unknown>)[name] === 'function'
+            && !MANUAL_IMPORT_ONLY.has(name)
+            && !userExclude.has(name),
+          ),
+        }
+
+    if (directusSdkImports) {
+      addImportsSources(directusSdkImports)
+    }
 
     nuxtApp.hook('nitro:config', (nitroConfig) => {
       nitroConfig.alias = nitroConfig.alias || {}
 
       nitroConfig.imports = nitroConfig.imports || {}
       nitroConfig.imports.presets = nitroConfig.imports.presets || []
-      nitroConfig.imports.presets.push(directusSdkImports)
+      if (directusSdkImports) {
+        nitroConfig.imports.presets.push(directusSdkImports)
+      }
       nitroConfig.imports.presets.push({
         from: resolver.resolve('./runtime/server/services'),
         imports: [

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,6 +10,7 @@ import { joinURL } from 'ufo'
 import { name, version } from '../package.json'
 import { generateTypesFromDirectus } from './runtime/types'
 import { useUrl } from './runtime/utils'
+import { discoverSdkImports } from './sdk-imports'
 
 export type DirectusUrl = string | { client: string, server: string }
 export type ReadMeFields = Query<DirectusSchema, DirectusSchema['directus_users']>['fields']
@@ -436,32 +437,6 @@ export default defineNuxtModule<ModuleOptions>({
     // Add composables
     addImportsDir(resolver.resolve('./runtime/composables'))
 
-    // Auto-import every function @directus/sdk exports, except for the
-    // following which the module either wraps, provides a composable for,
-    // or explicitly does not support. Users can still import them manually
-    // from '@directus/sdk' when they have a deliberate reason to.
-    //
-    // Keep MANUAL_IMPORT_ONLY in sync with docs/api/composables/index.md.
-    const MANUAL_IMPORT_ONLY = new Set([
-      // Client construction — useDirectus() returns a fully-configured
-      // singleton with auth, rest, realtime, and SSR cookie forwarding.
-      'createDirectus',
-      'rest',
-      'realtime',
-      'staticToken',
-      'authentication',
-      // Auth internals — use the auth composables (useDirectusAuth, etc.)
-      'auth',
-      'getAuthEndpoint',
-      // Storage primitive — use useDirectusStorage()
-      'memoryStorage',
-      // GraphQL — the module does not wrap or support GraphQL. Imported
-      // manually to keep users' expectations explicit about what this
-      // module covers.
-      'graphql',
-      'readGraphqlSdl',
-    ])
-
     // autoImportSdk=false disables auto-imports entirely; the { exclude }
     // shape adds user-provided names on top of the built-in exclusions.
     const autoImportSdk = options.autoImportSdk ?? true
@@ -475,11 +450,7 @@ export default defineNuxtModule<ModuleOptions>({
       ? null
       : {
           from: '@directus/sdk',
-          imports: Object.keys(directusSdk).filter(name =>
-            typeof (directusSdk as Record<string, unknown>)[name] === 'function'
-            && !MANUAL_IMPORT_ONLY.has(name)
-            && !userExclude.has(name),
-          ),
+          imports: discoverSdkImports(directusSdk as Record<string, unknown>, userExclude),
         }
 
     if (directusSdkImports) {

--- a/src/sdk-imports.ts
+++ b/src/sdk-imports.ts
@@ -1,0 +1,69 @@
+// Client factories / composables: module-level setup, not per-request commands.
+// Also includes GraphQL exports — the module does not wrap or support GraphQL;
+// keeping them as manual imports makes that boundary explicit.
+const SDK_CLIENT_FACTORIES = new Set([
+  'createDirectus',
+  'rest',
+  'graphql',
+  'authentication',
+  'staticToken',
+  'realtime',
+  'memoryStorage',
+  'readGraphqlSdl',
+])
+
+// Realtime low-level internals not intended for direct use.
+const SDK_REALTIME_INTERNALS = new Set([
+  'auth',
+  'pong',
+  'sleep',
+  'messageCallback',
+])
+
+// SDK internal utilities that are implementation details.
+const SDK_INTERNALS = new Set([
+  'throwIfEmpty',
+  'throwIfCoreCollection',
+  'getAuthEndpoint',
+  'formatFields',
+  'queryToParams',
+])
+
+// SDK functions already wrapped by this module's composables.
+// auth.ts:    readMe, updateMe, createUser, inviteUser, acceptUserInvite, passwordRequest, passwordReset
+// files.ts:   uploadFiles (composable handles FormData construction)
+export const SDK_COMPOSABLE_WRAPPED = new Set([
+  'readMe',
+  'updateMe',
+  'createUser',
+  'inviteUser',
+  'acceptUserInvite',
+  'passwordRequest',
+  'passwordReset',
+  'uploadFiles',
+])
+
+export const SDK_DENYLIST = new Set([
+  ...SDK_CLIENT_FACTORIES,
+  ...SDK_REALTIME_INTERNALS,
+  ...SDK_INTERNALS,
+  ...SDK_COMPOSABLE_WRAPPED,
+])
+
+/**
+ * Dynamically discovers available function exports from the Directus SDK.
+ *
+ * Filters out internal utilities, low-level APIs, and functions already wrapped
+ * by this module, returning only user-facing SDK methods. Pass `userExclude` to
+ * additionally suppress specific names (from the `autoImportSdk.exclude` option).
+ *
+ * @returns {string[]} A list of allowed SDK function names.
+ */
+export function discoverSdkImports(
+  sdkModule: Record<string, unknown>,
+  userExclude: Set<string> = new Set(),
+): string[] {
+  return Object.keys(sdkModule).filter(
+    key => typeof sdkModule[key] === 'function' && !SDK_DENYLIST.has(key) && !userExclude.has(key),
+  )
+}

--- a/test/sdk-auto-imports.test.ts
+++ b/test/sdk-auto-imports.test.ts
@@ -1,0 +1,60 @@
+import * as sdkModule from '@directus/sdk'
+import { describe, expect, it } from 'vitest'
+import { discoverSdkImports, SDK_COMPOSABLE_WRAPPED, SDK_DENYLIST } from '../src/sdk-imports'
+
+const sdkFunctions = new Set(
+  Object.keys(sdkModule).filter(key => typeof (sdkModule as any)[key] === 'function'),
+)
+
+describe('SDK_COMPOSABLE_WRAPPED stays in sync with @directus/sdk', () => {
+  it('every entry exists as a function in @directus/sdk', () => {
+    // If this fails, the SDK renamed or removed a wrapped function.
+    // Update SDK_COMPOSABLE_WRAPPED in src/sdk-imports.ts and the denylist table in docs/api/composables/index.md.
+    const missing = [...SDK_COMPOSABLE_WRAPPED].filter(fn => !sdkFunctions.has(fn))
+    expect(missing).toEqual([])
+  })
+})
+
+describe('SDK_DENYLIST stays in sync with @directus/sdk', () => {
+  it('every entry exists as a function in @directus/sdk', () => {
+    // If this fails, the SDK renamed or removed a blocked function.
+    // A renamed function would slip through the denylist as a new auto-import.
+    // Review sdk-imports.ts and update the relevant set.
+    const missing = [...SDK_DENYLIST].filter(fn => !sdkFunctions.has(fn))
+    expect(missing).toEqual([])
+  })
+})
+
+describe('discoverSdkImports', () => {
+  it('excludes all denylist entries', () => {
+    // If this fails, a blocked function is leaking into auto-imports.
+    // Add the leaking name to the appropriate set in src/sdk-imports.ts.
+    const imports = discoverSdkImports(sdkModule as any)
+    const leaked = imports.filter(fn => SDK_DENYLIST.has(fn))
+    expect(leaked).toEqual([])
+  })
+
+  it('contains only functions that exist in @directus/sdk', () => {
+    // If this fails, discoverSdkImports is returning a name that is not a function in the SDK.
+    // Check the filter logic in src/sdk-imports.ts.
+    const imports = discoverSdkImports(sdkModule as any)
+    const unknown = imports.filter(fn => !sdkFunctions.has(fn))
+    expect(unknown).toEqual([])
+  })
+
+  it('returns a non-empty list of importable functions', () => {
+    // If this fails, discoverSdkImports is filtering out everything.
+    // Check that SDK_DENYLIST in src/sdk-imports.ts has not grown to cover all SDK exports.
+    const imports = discoverSdkImports(sdkModule as any)
+    expect(imports.length).toBeGreaterThan(0)
+  })
+
+  it('respects userExclude', () => {
+    // If this fails, discoverSdkImports is ignoring the userExclude parameter.
+    // Check the filter logic in src/sdk-imports.ts.
+    const userExclude = new Set(['aggregate', 'withToken'])
+    const imports = discoverSdkImports(sdkModule as any, userExclude)
+    expect(imports).not.toContain('aggregate')
+    expect(imports).not.toContain('withToken')
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the hand-maintained list of ~54 auto-imported SDK functions with dynamic discovery of every function `@directus/sdk` exports. The module reads the SDK's exports at build time, so whichever version of `@directus/sdk` the user installs, those functions are what gets auto-imported.

Closes #43.

### What's excluded from auto-import

A small set of SDK functions remain manual imports — each for a specific reason:

- **Client construction** (`createDirectus`, `rest`, `realtime`, `staticToken`, `authentication`) — the module wraps these via `useDirectus()`, which returns a singleton with auth, rest, realtime, and SSR cookie forwarding already attached. Using these directly bypasses module features users probably want.
- **Auth internals** (`auth`, `getAuthEndpoint`) — use the auth composables (`useDirectusAuth`, etc.) instead.
- **Storage primitive** (`memoryStorage`) — use `useDirectusStorage()` instead.
- **GraphQL** (`graphql`, `readGraphqlSdl`) — the module does not wrap or support GraphQL. Kept manual so users are explicit about using it.

Full table with "why" for each is in the updated docs.

### New `autoImportSdk` option

```typescript
directus: {
  autoImportSdk?: boolean | { exclude?: string[] }
}
```

- `true` (default) — auto-import everything except the built-in exclusions
- `false` — disable auto-imports entirely (import everything manually)
- `{ exclude: [...] }` — auto-import with user-defined additions to the exclusion list (useful for name collisions)

Tree-shaking handles unused auto-imports at the consumer's bundle layer, so the wider auto-import surface has zero bundle-size cost.

### Docs

- [`docs/api/composables/index.md`](docs/api/composables/index.md) now documents the new behaviour, the excluded functions (with a one-line "why" each), and how to disable or customise auto-imports
- [`docs/api/configuration/module.md`](docs/api/configuration/module.md) adds the `autoImportSdk` option

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run test` — all 228 tests pass
- [x] `pnpm run dev:prepare` — playground types generate correctly
- [ ] Merge into `next`