### PR TITLE
feat(cli): add generate-types subcommand

### DIFF
--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -330,6 +330,43 @@ export default defineNuxtConfig({
 })
 ```
 
+##### Generating types from the CLI
+
+In addition to generating types automatically during `nuxt dev` / `nuxt build`, you can generate them on demand using the CLI. Useful for CI pipelines, pre-commit hooks, or any workflow where you want `.d.ts` output without a Nuxt build.
+
+```bash
+# Pipe to a file (uses DIRECTUS_URL + DIRECTUS_ADMIN_TOKEN from .env)
+npx nuxt-directus-sdk generate-types > types/directus.d.ts
+
+# Inline env vars — useful for one-off runs against a specific instance
+DIRECTUS_URL=https://my-directus.com \
+DIRECTUS_ADMIN_TOKEN=my-token \
+  npx nuxt-directus-sdk generate-types > types/directus.d.ts
+
+# Write directly to a file
+npx nuxt-directus-sdk generate-types -o types/directus.d.ts
+
+# Add a prefix to custom collection type names
+npx nuxt-directus-sdk generate-types --prefix App -o types/directus.d.ts
+
+# Flags override env vars
+npx nuxt-directus-sdk generate-types \
+  --url https://my-directus.com \
+  --token $DIRECTUS_ADMIN_TOKEN \
+  -o types/directus.d.ts
+
+# Emit without the `declare global { ... }` wrapper (non-Nuxt consumers)
+npx nuxt-directus-sdk generate-types --no-declare-global -o types/directus.d.ts
+```
+
+By default the CLI writes to stdout, so you can pipe the output anywhere. The `-o` flag writes to a file and creates parent directories if they don't exist. Informational logs (e.g. "Fetched 42 collections...") go to stderr so they don't pollute piped output.
+
+Precedence for URL and token: CLI flag → exported/inline env var → `.env` file in the current directory.
+
+::: tip Keeping types in version control
+Running `generate-types` in CI and committing the output is a common pattern — it keeps your team working with consistent types without requiring each developer to have their own admin token or a local Nuxt build. Just make sure the CI job has access to the Directus instance and an admin token.
+:::
+
 ##### Type Prefix
 
 Add a prefix to your custom collection types to avoid naming conflicts:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
 /**
- * Directus Rules CLI
+ * nuxt-directus-sdk CLI
  *
  * Commands:
- *   rules:pull   - Download rules from Directus and save as JSON
- *   rules:diff   - Compare local rules with remote Directus
- *   rules:diff-remote - Compare two remote Directus instances
+ *   rules:pull         - Download rules from Directus and save as JSON
+ *   rules:push         - Push local JSON rules to remote Directus
+ *   rules:diff         - Compare local rules with remote Directus
+ *   rules:diff-files   - Compare two local JSON files
+ *   rules:diff-remote  - Compare two remote Directus instances
+ *   generate-types     - Generate TypeScript types from a Directus schema
  */
 
 /* eslint-disable node/prefer-global/process */
 
 import type { DirectusRulesPayload } from '../rules/types/directus-api'
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
 import { parseArgs } from 'node:util'
 import { createDirectus, rest, staticToken } from '@directus/sdk'
 import { loadRulesFromPayload } from '../rules/loaders'
@@ -25,6 +28,7 @@ import {
   formatPushResult,
   pushRules,
 } from '../rules/sync'
+import { generateTypesFromDirectus } from '../runtime/types/generate'
 
 interface ConnectionConfig {
   url: string
@@ -64,13 +68,19 @@ function getConnectionConfig(
 
   if (!url) {
     console.error(`Error: ${label} URL is required`)
-    console.error(`Provide --${label.toLowerCase()}-url or set DIRECTUS_URL in your .env file`)
+    const flagHint = label === 'Source'
+      ? '--url (or --source-url)'
+      : `--${label.toLowerCase()}-url`
+    console.error(`Provide ${flagHint} or set DIRECTUS_URL in your .env file`)
     process.exit(1)
   }
 
   if (!token) {
     console.error(`Error: ${label} token is required`)
-    console.error(`Provide --${label.toLowerCase()}-token or set DIRECTUS_ADMIN_TOKEN in your .env file`)
+    const flagHint = label === 'Source'
+      ? '--token (or --source-token)'
+      : `--${label.toLowerCase()}-token`
+    console.error(`Provide ${flagHint} or set DIRECTUS_ADMIN_TOKEN in your .env file`)
     process.exit(1)
   }
 
@@ -85,7 +95,7 @@ function createClient(url: string, token: string) {
 
 function printHelp(): void {
   console.log(`
-Directus Rules CLI
+nuxt-directus-sdk CLI
 
 Usage:
   npx nuxt-directus-sdk <command> [options]
@@ -96,24 +106,29 @@ Commands:
   rules:diff <file>         Compare local JSON file with remote Directus
   rules:diff-files <a> <b>  Compare two local JSON files
   rules:diff-remote         Compare two remote Directus instances
+  generate-types            Generate TypeScript types from a Directus schema
 
 Options:
   -h, --help                Show this help message
-  -o, --output <file>       Output file path (default: rules.json)
+  -o, --output <file>       Output file path (default: stdout for generate-types, rules.json for rules:pull)
   --compact                 Output compact JSON (no pretty-print)
   --dry-run                 Show what would be changed without making changes (rules:push)
   --add-only                Only add new items, don't modify or delete existing (rules:push)
   --skip-deletes            Skip deleting items that exist remotely but not locally (rules:push)
+  --prefix <prefix>         Prefix for custom collection type names (generate-types)
+  --no-declare-global       Emit types without the \`declare global\` wrapper (generate-types)
 
   Connection options (override DIRECTUS_URL / DIRECTUS_ADMIN_TOKEN):
+  --url <url>               Directus URL (alias of --source-url)
+  --token <token>           Admin token (alias of --source-token)
   --source-url <url>        Source Directus URL
   --source-token <token>    Source admin token
   --target-url <url>        Target Directus URL (for rules:diff-remote)
   --target-token <token>    Target admin token (for rules:diff-remote)
 
 Environment Variables:
-  DIRECTUS_URL              Default Directus URL (used if --source-url not provided)
-  DIRECTUS_ADMIN_TOKEN      Default admin token (used if --source-token not provided)
+  DIRECTUS_URL              Default Directus URL (used if --url / --source-url not provided)
+  DIRECTUS_ADMIN_TOKEN      Default admin token (used if --token / --source-token not provided)
 
 Examples:
   # Pull rules from Directus (uses env vars)
@@ -141,6 +156,15 @@ Examples:
   npx nuxt-directus-sdk rules:diff-remote \\
     --source-url https://staging.example.com --source-token staging-token \\
     --target-url https://production.example.com --target-token production-token
+
+  # Generate TypeScript types, pipe to a file
+  npx nuxt-directus-sdk generate-types > types/directus.d.ts
+
+  # Generate types with a prefix, write directly to a file
+  npx nuxt-directus-sdk generate-types --prefix App -o types/directus.d.ts
+
+  # Generate types from a specific instance
+  npx nuxt-directus-sdk generate-types --url https://my-directus.com --token my-token
 `)
 }
 
@@ -289,6 +313,49 @@ async function commandPush(
   }
 }
 
+async function commandGenerateTypes(
+  connection: ConnectionConfig,
+  options: { prefix: string, output: string | undefined, declareGlobal: boolean },
+): Promise<void> {
+  // Informational logs go to stderr so they don't pollute stdout when piping
+  console.error(`Generating types from ${connection.url}...`)
+
+  const { typeString, logs } = await generateTypesFromDirectus(
+    connection.url,
+    connection.token,
+    options.prefix,
+  )
+
+  // Surface the generator's own logs (e.g. fetch counts, errors) to stderr
+  for (const line of logs) {
+    console.error(line)
+  }
+
+  if (!typeString) {
+    console.error('Error: Type generation returned empty output.')
+    process.exit(1)
+  }
+
+  // Strip the `declare global { ... }` wrapper for non-Nuxt consumers.
+  // The wrapper spans the entire file: first line `declare global {`, last
+  // body line `}`, followed by `export {};` which we also drop.
+  const output = options.declareGlobal
+    ? typeString
+    : typeString
+        .replace(/^declare global \{\n\n/, '')
+        .replace(/\n\}\n\nexport \{\};?\n?$/, '\n')
+
+  if (options.output) {
+    const outputPath = resolve(process.cwd(), options.output)
+    mkdirSync(dirname(outputPath), { recursive: true })
+    writeFileSync(outputPath, output, 'utf-8')
+    console.error(`Types written to ${outputPath}`)
+  }
+  else {
+    process.stdout.write(output)
+  }
+}
+
 async function main(): Promise<void> {
   loadEnv()
 
@@ -296,11 +363,17 @@ async function main(): Promise<void> {
     allowPositionals: true,
     options: {
       'help': { type: 'boolean', short: 'h' },
-      'output': { type: 'string', short: 'o', default: 'rules.json' },
+      // `output` has no default here — each command applies its own fallback
+      // (rules:pull defaults to rules.json, generate-types defaults to stdout).
+      'output': { type: 'string', short: 'o' },
       'compact': { type: 'boolean', default: false },
       'dry-run': { type: 'boolean', default: false },
       'add-only': { type: 'boolean', default: false },
       'skip-deletes': { type: 'boolean', default: false },
+      'prefix': { type: 'string', default: '' },
+      'declare-global': { type: 'boolean', default: true },
+      'url': { type: 'string' },
+      'token': { type: 'string' },
       'source-url': { type: 'string' },
       'source-token': { type: 'string' },
       'target-url': { type: 'string' },
@@ -319,12 +392,12 @@ async function main(): Promise<void> {
     switch (command) {
       case 'rules:pull': {
         const connection = getConnectionConfig(
-          values['source-url'],
-          values['source-token'],
+          values['source-url'] ?? values.url,
+          values['source-token'] ?? values.token,
           'Source',
         )
         await commandPull({
-          output: values.output!,
+          output: values.output ?? 'rules.json',
           compact: values.compact!,
         }, connection)
         break
@@ -337,8 +410,8 @@ async function main(): Promise<void> {
           process.exit(1)
         }
         const connection = getConnectionConfig(
-          values['source-url'],
-          values['source-token'],
+          values['source-url'] ?? values.url,
+          values['source-token'] ?? values.token,
           'Source',
         )
         await commandPush(positionals[1], connection, {
@@ -356,8 +429,8 @@ async function main(): Promise<void> {
           process.exit(1)
         }
         const connection = getConnectionConfig(
-          values['source-url'],
-          values['source-token'],
+          values['source-url'] ?? values.url,
+          values['source-token'] ?? values.token,
           'Source',
         )
         await commandDiff(positionals[1], connection)
@@ -375,8 +448,8 @@ async function main(): Promise<void> {
 
       case 'rules:diff-remote': {
         const source = getConnectionConfig(
-          values['source-url'],
-          values['source-token'],
+          values['source-url'] ?? values.url,
+          values['source-token'] ?? values.token,
           'Source',
         )
         const target = getConnectionConfig(
@@ -385,6 +458,20 @@ async function main(): Promise<void> {
           'Target',
         )
         await commandDiffRemote(source, target)
+        break
+      }
+
+      case 'generate-types': {
+        const connection = getConnectionConfig(
+          values.url ?? values['source-url'],
+          values.token ?? values['source-token'],
+          'Source',
+        )
+        await commandGenerateTypes(connection, {
+          prefix: values.prefix ?? '',
+          output: values.output,
+          declareGlobal: values['declare-global']!,
+        })
         break
       }
 


### PR DESCRIPTION
## Summary

Adds a `generate-types` subcommand to the existing CLI. Lets users generate TypeScript types from a Directus schema outside of a Nuxt build cycle — useful for CI, pre-commit hooks, or non-Nuxt consumers who want the typed schema.

## Usage

```bash
# Uses DIRECTUS_URL + DIRECTUS_ADMIN_TOKEN from .env, pipes to a file
npx nuxt-directus-sdk generate-types > types/directus.d.ts

# Inline env vars — useful for one-off runs against a specific instance
DIRECTUS_URL=https://my-directus.com \
DIRECTUS_ADMIN_TOKEN=my-token \
  npx nuxt-directus-sdk generate-types > types/directus.d.ts

# Write directly to a file
npx nuxt-directus-sdk generate-types -o types/directus.d.ts

# With a prefix
npx nuxt-directus-sdk generate-types --prefix App -o types/directus.d.ts

# Flags override env vars
npx nuxt-directus-sdk generate-types \
  --url https://my-directus.com \
  --token $DIRECTUS_ADMIN_TOKEN \
  -o types/directus.d.ts

# Non-Nuxt consumers who want top-level interfaces (no declare global wrapper)
npx nuxt-directus-sdk generate-types --no-declare-global -o types/directus.d.ts
```

Precedence for URL and token: CLI flag → exported/inline env var → `.env` file in the current directory.

## Design choices

- **Default output is stdout.** Matches the unix-philosophy convention most codegen tools use (Prisma, Zod, etc.). `-o <file>` is an opt-in that also creates parent directories.
- **Informational logs go to stderr.** "Generating types from...", "Fetched N collections..." etc. — never pollutes the stdout stream when piping.
- **`--url` / `--token` as primary flags, `--source-url` / `--source-token` as aliases.** Matches the CLI's existing source/target naming for rules commands while giving `generate-types` a cleaner single-command flag shape.
- **`--no-declare-global`** for non-Nuxt consumers who want `export interface Foo {...}` instead of `declare global { interface Foo {...} }`.

## Internal refactor

The top-level `-o, --output` flag no longer has a default value. Each command applies its own fallback:
- `rules:pull` → `rules.json`
- `generate-types` → stdout

## Follow-ups (separate PR)

- `--exclude <names>` flag to omit specific collections (in progress — stacked on top of this branch)
- Corresponding `types.exclude` module option

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run test` — all 228 tests pass
- [x] `pnpm run prepack` builds `dist/cli/index.mjs` cleanly
- [x] Smoke test against a real Directus instance (playground/.env): fetched 109 collections, 980 fields, 220 relations; types generate with the expected `Rolley` prefix
- [x] `--help` renders correctly
- [x] Missing-URL error message reads sensibly