### PR TITLE
chore(pkg): add homepage, bugs, keywords and sharpen description

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,13 +3,29 @@
   "type": "module",
   "version": "6.0.0-beta.0",
   "packageManager": "pnpm@10.32.1",
-  "description": "A Directus nuxt module that uses the Directus SDK",
+  "description": "A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.",
   "author": "Matthew Rollinson <matt@rolley.io>",
   "license": "MIT",
+  "homepage": "https://nuxt-directus-sdk.rolley.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/rolleyio/nuxt-directus-sdk"
   },
+  "bugs": {
+    "url": "https://github.com/rolleyio/nuxt-directus-sdk/issues"
+  },
+  "keywords": [
+    "nuxt",
+    "nuxt-module",
+    "directus",
+    "cms",
+    "headless-cms",
+    "sdk",
+    "ssr",
+    "realtime",
+    "authentication",
+    "visual-editor"
+  ],
   "exports": {
     ".": {
       "types": "./dist/module.d.mts",


### PR DESCRIPTION
## Summary

Fills in the metadata fields that npm, the nuxt.com/modules directory, and module-health aggregators like nuxt.care scrape from `package.json`. Groundwork for submitting the module to nuxt.com/modules.

Changes to `package.json`:

- **`description`**: rewritten to name what's actually built in (auth, realtime, files, type generation, visual editor) rather than the generic "uses the Directus SDK". Matches the docs tagline.
- **`homepage`**: points at the docs site (`https://nuxt-directus-sdk.rolley.io`).
- **`bugs`**: points at the issue tracker.
- **`keywords`**: standard set for Nuxt CMS modules plus Directus-specific terms (`cms`, `headless-cms`, `realtime`, `visual-editor`, etc).

No behavioural changes. All 228 tests still pass, lint clean.

## Follow-up

Once merged, I'll prepare the nuxt/modules PR to submit the module to the listing.