### PR TITLE
feat!: rename useServerDirectus → useSessionDirectus

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -227,7 +227,7 @@ export default defineNuxtConfig({
 ```typescript
 // server/api/profile.ts
 export default defineEventHandler(async (event) => {
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
 
   // This request is automatically authenticated with the user's session
   const user = await directus.request(readMe())
@@ -416,7 +416,7 @@ export default defineNuxtConfig({
 
 ### SSR Issues
 
-1. ✅ Use `useServerDirectus(event)` in server routes (not `useDirectus()`)
+1. ✅ Use `useSessionDirectus(event)` in server routes (not `useDirectus()`)
 2. ✅ Check cookies are being forwarded on SSR (automatic with this module)
 3. ✅ Verify server-side requests include session cookie
 

--- a/docs/guide/server-side.md
+++ b/docs/guide/server-side.md
@@ -6,21 +6,21 @@ nuxt-directus-sdk provides server-side utilities for authenticating Directus req
 
 The module provides several server utilities:
 
-- **`useServerDirectus(event)`** - Authenticated requests using user session
+- **`useSessionDirectus(event)`** - Authenticated requests using user session
 - **`useAdminDirectus()`** - Admin requests using admin token
 - **`useTokenDirectus(token)`** - Custom token authentication
 - **`getDirectusSessionToken(event)`** - Manual token extraction
 
 ## User Authentication
 
-### `useServerDirectus(event)`
+### `useSessionDirectus(event)`
 
 Use the current user's session token for authenticated requests:
 
 ```typescript
 // server/api/profile.ts
 export default defineEventHandler(async (event) => {
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
 
   // This request uses the user's session token
   const user = await directus.request(readMe())
@@ -39,7 +39,7 @@ This automatically:
 ```typescript
 // server/api/my-articles.ts
 export default defineEventHandler(async (event) => {
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
 
   try {
     // Get current user
@@ -216,7 +216,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
 
   // Get user data
   const user = await directus.request(readMe())
@@ -251,7 +251,7 @@ export default defineEventHandler(async (event) => {
   let scope = 'public'
 
   if (userToken) {
-    directus = useServerDirectus(event)
+    directus = useSessionDirectus(event)
     const user = await directus.request(readMe())
 
     // Admins get full data
@@ -308,7 +308,7 @@ export default defineEventHandler(async (event) => {
 ```typescript
 // server/api/upload.ts
 export default defineEventHandler(async (event) => {
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
 
   // Read multipart form data
   const files = await readFiles(event)
@@ -384,7 +384,7 @@ export async function fetchWithAuth<T>(
   collection: string,
   query?: Query<DirectusSchema, any>
 ) {
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
   return directus.request(readItems(collection, query))
 }
 
@@ -405,7 +405,7 @@ export default defineEventHandler(async (event) => {
 ```typescript
 // server/utils/auth.ts
 export async function requireRole(event: H3Event, requiredRole: string) {
-  const directus = useServerDirectus(event)
+  const directus = useSessionDirectus(event)
 
   const user = await directus.request(readMe({
     fields: ['id', 'email', 'role.*'],
@@ -473,7 +473,7 @@ Get your admin token from Directus:
        throw createError({ status: 400, statusText: 'Invalid email' })
      }
 
-     const directus = useServerDirectus(event)
+     const directus = useSessionDirectus(event)
      // Proceed with validated data
    })
    ```
@@ -481,7 +481,7 @@ Get your admin token from Directus:
 3. **Use appropriate authentication level**
    ```typescript
    // User operations - use user session
-   const directus = useServerDirectus(event)
+   const directus = useSessionDirectus(event)
 
    // Admin operations - use admin token
    const directus = useAdminDirectus()
@@ -489,7 +489,7 @@ Get your admin token from Directus:
 
 ## API Reference
 
-### `useServerDirectus(event)`
+### `useSessionDirectus(event)`
 
 Create a Directus client authenticated with the user's session token.
 
@@ -500,7 +500,7 @@ Create a Directus client authenticated with the user's session token.
 
 **Example:**
 ```typescript
-const directus = useServerDirectus(event)
+const directus = useSessionDirectus(event)
 const user = await directus.request(readMe())
 ```
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -12,7 +12,7 @@
     <h2>Playground To Do's:</h2>
     <ul>
       <li>Visual Editor Example</li>
-      <li>useServerDirectus</li>
+      <li>useSessionDirectus</li>
       <li>useAdminDirectus</li>
       <li>useTokenDirectus</li>
       <li>loginWithProvider</li>

--- a/src/module.ts
+++ b/src/module.ts
@@ -519,7 +519,7 @@ export default defineNuxtModule<ModuleOptions>({
         imports: [
           'getDirectusSessionToken',
           'useAdminDirectus',
-          'useServerDirectus',
+          'useSessionDirectus',
           'useDirectusUrl',
           'useTokenDirectus',
         ],

--- a/src/runtime/server/services/directus.ts
+++ b/src/runtime/server/services/directus.ts
@@ -29,8 +29,8 @@ export function useTokenDirectus(token?: string) {
   return directus
 }
 
-export function useServerDirectus(event: H3Event) {
-  // Get cookie header from the incoming request
+export function useSessionDirectus(event: H3Event) {
+  // Derive the client's auth from the session cookie on the incoming request.
   return useTokenDirectus(getDirectusSessionToken(event))
 }
 


### PR DESCRIPTION
## Summary

Renames the server-side composable `useServerDirectus(event)` to `useSessionDirectus(event)`.

**Stacked on #47.** GitHub will auto-retarget to `next` once that merges.

## Migration

Find and replace every call site. Signature and behaviour are unchanged; auto-import registration picks up the new name automatically.

```diff
- const directus = useServerDirectus(event)
+ const directus = useSessionDirectus(event)
```

## Why

"Server" was ambiguous. It could mean "server-side" (what this actually is) or "the Directus server" (which every Directus client already talks to). The new name tells you how auth is supplied — from the session cookie — which is what differentiates it from the rest of the server-side family:

- `useSessionDirectus(event)` — session cookie from the request
- `useTokenDirectus(token?)` — arbitrary token
- `useAdminDirectus()` — admin token

Same pattern the other helpers already follow. Now consistent.

## Scope

- `src/runtime/server/services/directus.ts` — export renamed
- `src/module.ts` — auto-import registration updated
- `docs/guide/authentication.md`, `docs/guide/server-side.md` — all mentions updated
- `playground/pages/index.vue` — updated the todo list reference

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm run test` — 267 tests pass
- [x] `pnpm run docs:build` — all links valid, sitemap generated
- [x] `pnpm run prepack` — `useSessionDirectus` exported in `dist/runtime/server/services/directus.d.ts`; no trace of `useServerDirectus` in the built output
- [ ] Merge after PR #47

## Breaking change scope

5.x users upgrading to 6.x need to find-and-replace. Flagged as `feat!:` so changelogen picks it up in the 6.0 release notes alongside the peer-dep bumps and the component removal from #47.