### PR TITLE
chore(ci): drop redundant prepack step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Required before prepack — nuxt-module-build extends playground/.nuxt/tsconfig.json
+      # Required before publish — nuxt-module-build (invoked by npm's prepack
+      # lifecycle hook during publish) extends playground/.nuxt/tsconfig.json
       - run: pnpm run dev:prepare
-
-      - run: pnpm run prepack
 
       - name: Determine npm tag
         id: npm-tag


### PR DESCRIPTION
## Summary
- `npm publish` runs `prepack` automatically via its lifecycle hooks (see [npm-publish docs](https://docs.npmjs.com/cli/v11/commands/npm-publish))
- The explicit `pnpm run prepack` step was building `dist/` twice and adding ~10-15s to release time
- Kept `dev:prepare` because `nuxt-module-build` (which npm's prepack hook invokes) still needs `playground/.nuxt/tsconfig.json`

## Test plan
- [ ] CI passes on this PR
- [ ] Next release (`v6.0.0-beta.2` when cut) still publishes a valid `dist/` to npm