### PR TITLE
chore: release 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,30 @@
 {
   "name": "nuxt-directus-sdk",
   "type": "module",
-  "version": "5.0.2",
-  "description": "A Directus nuxt module that uses the Directus SDK",
+  "version": "5.0.3",
+  "description": "A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.",
   "author": "Matthew Rollinson <matt@rolley.io>",
   "license": "MIT",
+  "homepage": "https://nuxt-directus-sdk.rolley.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/rolleyio/nuxt-directus-sdk"
   },
+  "bugs": {
+    "url": "https://github.com/rolleyio/nuxt-directus-sdk/issues"
+  },
+  "keywords": [
+    "nuxt",
+    "nuxt-module",
+    "directus",
+    "cms",
+    "headless-cms",
+    "sdk",
+    "ssr",
+    "realtime",
+    "authentication",
+    "visual-editor"
+  ],
   "exports": {
     ".": {
       "types": "./dist/module.d.mts",
@@ -90,5 +106,8 @@
     "externals": [
       "consola/utils"
     ]
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
## Summary
Metadata-only patch release. Backports PR #49's \`package.json\` improvements onto \`main\` so \`latest\` on npm matches what the nuxt.com/modules catalogue sync tool will read.

Changes:
- description: clearer one-line summary
- homepage: points at docs site (\`nuxt-directus-sdk.rolley.io\`)
- bugs: issue tracker URL
- keywords: standard Nuxt/CMS tags plus Directus-specific
- engines.node: \`>=18.0.0\` (required by the nuxt.com/modules catalogue)

No code changes, no behaviour changes.

## Context
We're about to submit to [nuxt.com/modules](https://nuxt.com/modules). The sync tool reads live \`latest\` metadata from npm, so shipping this before opening the catalogue PR avoids a mismatch between the published package and the catalogue entry.

## Test plan
- [ ] Merge triggers release on tag push
- [ ] 5.0.3 publishes to npm under \`latest\`
- [ ] npm registry shows updated description, homepage, keywords, engines