### PR TITLE
docs: update changelog for v5.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v5.0.2...v5.0.3
+
+[compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v5.0.2...v5.0.3)
+
+### 📖 Documentation
+
+- Update changelog for v5.0.2 ([6a0362b](https://github.com/rolleyio/nuxt-directus-sdk/commit/6a0362b))
+
+### 🏡 Chore
+
+- Bump version to 5.0.3 ([8beb89a](https://github.com/rolleyio/nuxt-directus-sdk/commit/8beb89a))
+
+### ❤️ Contributors
+
+- Matthew Rollinson <matt@rolley.io>
+
 ## v5.0.1...v5.0.2
 
 [compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v5.0.1...v5.0.2)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v5.0.2...v5.0.3
+
+[compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v5.0.2...v5.0.3)
+
+### 📖 Documentation
+
+- Update changelog for v5.0.2 ([6a0362b](https://github.com/rolleyio/nuxt-directus-sdk/commit/6a0362b))
+
+### 🏡 Chore
+
+- Bump version to 5.0.3 ([8beb89a](https://github.com/rolleyio/nuxt-directus-sdk/commit/8beb89a))
+
+### ❤️ Contributors
+
+- Matthew Rollinson <matt@rolley.io>
+
 ## v5.0.1...v5.0.2
 
 [compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v5.0.1...v5.0.2)


### PR DESCRIPTION
## Summary
- Add v5.0.3 changelog section to \`CHANGELOG.md\` and \`docs/changelog.md\`
- Generated with \`bunx changelogen --from v5.0.2 --to v5.0.3\`

Manual follow-up because the release workflow's changelog-commit step fails on \`main\` (tries to push to \`next\`, which has diverged). The new release pipeline on \`next\` drops this step entirely and uses \`changelogithub\` for release notes, so this bookkeeping task goes away when \`main\` catches up post-6.0.

## Test plan
- [ ] Merge onto main
- [ ] Create GitHub release for v5.0.3