### PR TITLE
chore: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Summary
+
+<!-- What does this change and why? -->
+
+### Linked issue
+
+<!-- e.g. closes #42. Delete this section if not applicable. -->
+
+### Checklist
+
+- [ ] Tests added or updated (new features and bug fixes)
+- [ ] Playground updated if the feature is user-visible
+- [ ] Docs updated if behaviour or configuration changed
+- [ ] Targeting `next` branch (unless this is a hotfix for `main`)
+- [ ] `pnpm lint` and `pnpm test` pass locally


### PR DESCRIPTION
### Summary

Adds \`.github/PULL_REQUEST_TEMPLATE.md\` so the GitHub web UI pre-fills new PRs with a short checklist. Addresses @kheiner's request in #62.

The checklist nudges contributors to add tests, update the playground for user-visible features, refresh docs, and target \`next\` (not \`main\`) by default.

### Linked issue

Closes #62.

### Checklist

- [x] Tests added or updated (n/a — docs-only)
- [x] Playground updated if the feature is user-visible (n/a)
- [x] Docs updated if behaviour or configuration changed (n/a)
- [x] Targeting \`next\` branch
- [x] \`pnpm lint\` and \`pnpm test\` pass locally (no code changed)