### PR TITLE
suggestions for #68

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -275,12 +275,15 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   async setup(options, nuxtApp) {
+    // set up array to send logs in messagebox
+    const loggerMessage: string[] = []
+
     // Resolve client and server URLs from the url option
     const clientUrl = typeof options.url === 'string' ? options.url : options.url?.client
     const serverUrl = typeof options.url === 'string' ? options.url : options.url?.server
 
     if (!clientUrl) {
-      logger.warn('No Directus URL found at build time. Set it in config options, .env file as DIRECTUS_URL, or at runtime via NUXT_PUBLIC_DIRECTUS_URL.')
+      loggerMessage.push(`⚠️ No Directus URL found at build time:`, `  - Set it in config options, .env file as DIRECTUS_URL or at runtime via NUXT_PUBLIC_DIRECTUS_URL.`, '')
     }
 
     const resolver = createResolver(import.meta.url)
@@ -294,8 +297,6 @@ export default defineNuxtModule<ModuleOptions>({
         (nuxtApp.options as any)[key] = defu((nuxtApp.options as any)[key], moduleOptions)
       }
     }
-    // set up array to send logs in messagebox
-    const loggerMessage: string[] = []
 
     // Normalize devProxy options
     const devProxyConfig = typeof options.devProxy === 'boolean'
@@ -396,7 +397,7 @@ export default defineNuxtModule<ModuleOptions>({
         wsPath: wsProxyPath,
       }
     }
-    else if (!nuxtApp.options.dev) {
+    else if (!nuxtApp.options.dev && directusUrl) {
       loggerMessage.push(`🌐 Production Mode:`, `  - SDK connects directly to ${colors.dim(`${directusUrl}`)}`, '')
       options.devProxy = false
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import type { Query } from '@directus/sdk'
+import type { DirectusUser, Query } from '@directus/sdk'
 import type { ImageModifiers, ImageProviders } from '@nuxt/image'
 import type { InlinePreset } from 'unimport'
 
@@ -13,7 +13,7 @@ import { useUrl } from './runtime/utils'
 import { discoverSdkImports } from './sdk-imports'
 
 export type DirectusUrl = string | { client: string, server: string }
-export type ReadMeFields = Query<DirectusSchema, DirectusSchema['directus_users']>['fields']
+export type ReadMeFields = Query<DirectusSchema, DirectusUser<DirectusSchema>>['fields']
 
 export interface ModuleOptions {
   /**

--- a/src/runtime/composables/files.ts
+++ b/src/runtime/composables/files.ts
@@ -1,5 +1,5 @@
 import type { DirectusFile, DirectusSchema } from '#build/types/directus'
-import type { Query } from '@directus/sdk'
+import type { DirectusFile as DirectusSdkFile, Query } from '@directus/sdk'
 import { uploadFiles } from '@directus/sdk'
 import { useDirectus, useDirectusUrl } from './directus'
 
@@ -8,13 +8,13 @@ interface DirectusFileUpload {
   data?: Record<keyof DirectusFile, string>
 }
 
-export async function uploadDirectusFile(file: DirectusFileUpload, query?: Query<DirectusSchema, DirectusSchema['directus_files']>) {
+export async function uploadDirectusFile(file: DirectusFileUpload, query?: Query<DirectusSchema, DirectusSdkFile<DirectusSchema>>) {
   const result = await uploadDirectusFiles([file], query)
 
   return (Array.isArray(result) ? result[0] : result)
 }
 
-export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Query<DirectusSchema, DirectusSchema['directus_files']>) {
+export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Query<DirectusSchema, DirectusSdkFile<DirectusSchema>>) {
   const directus = useDirectus()
   const formData = new FormData()
 
@@ -28,7 +28,7 @@ export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Q
     formData.append('file', file)
   })
 
-  return directus.request(uploadFiles(formData, query as any)) as unknown as DirectusFile[] | DirectusFile
+  return directus.request(uploadFiles(formData, query)) as unknown as DirectusFile[] | DirectusFile
 }
 
 export type DirectusThumbnailFormat = 'jpg' | 'png' | 'webp' | 'tiff' | 'avif'

--- a/src/runtime/types/fallback.d.ts
+++ b/src/runtime/types/fallback.d.ts
@@ -1,5 +1,6 @@
-export interface FallbackSchema {
-  directus_users?: Record<string, never>
-}
+export {}
 
-declare global { interface DirectusSchema extends FallbackSchema { } }
+declare global {
+  interface DirectusSchema {
+  }
+}

--- a/src/runtime/types/generate.ts
+++ b/src/runtime/types/generate.ts
@@ -296,23 +296,17 @@ export function transformSnapshotToTypeString(
 
   const customInterfaceBlocks = generatedCollections.map(g => g.interfaceBlock)
 
-  // Omit directus_* entries from the DirectusSchema map. The SDK already
-  // merges its own CoreSchema (every directus_* collection) into the client
-  // via CompleteSchema, so readMe / readUsers / readFiles / etc. still
-  // resolve against DirectusUser<Schema> and friends and pick up user-level
-  // customisations from the separately-emitted `interface DirectusUser {}`
-  // augmentations. Keeping directus_* in DirectusSchema only causes
-  // `readItems('directus_users')` to be suggested, which fails at runtime
-  // because system collections are not served from /items/*. See #65.
-  const schemaMapCollections = allCollectionsForSchema.filter(
-    c => !collectionIsDirectusSystem(c.collection),
-  )
-  const directusSchemaBlock = generateDirectusSchemaInterface(schemaMapCollections, prefix, singletonCollectionNames)
+  // System collections are emitted as non-array (singular) entries in DirectusSchema so that
+  // MergeCoreCollection<Schema, "directus_settings", ...> in the SDK can find the key and merge
+  // any custom fields into the return types.
+  // See: https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
+  const directusSchemaBlock = generateDirectusSchemaInterface(allCollectionsForSchema, prefix, singletonCollectionNames)
 
-  // The enum is user-facing sugar for iterating custom collection names, so
-  // it follows the same filter — consumers using it to build UI lists don't
-  // want `directus_activity` showing up in a dropdown.
-  const allCollectionNames = schemaMapCollections.map(c => c.collection)
+  // The enum is user-facing sugar for iterating custom collection names
+  // consumers using it to build UI lists don't want `directus_activity` showing up in a dropdown.
+  const allCollectionNames = allCollectionsForSchema
+    .filter(c => !collectionIsDirectusSystem(c.collection))
+    .map(c => c.collection)
   const enumBlock = generateCollectionNamesEnum(allCollectionNames, prefix)
 
   const bodyParts = [
@@ -749,8 +743,12 @@ function generateDirectusSchemaInterface(
 ): string {
   const entries = allCollections.map((collection) => {
     const isSingleton = collection.meta?.singleton === true
+    const isDirectusSystemCollection = collectionIsDirectusSystem(collection.collection)
     const interfaceName = collectionNameToInterfaceName(collection.collection, prefix, singletons)
-    const valueType = isSingleton ? interfaceName : `${interfaceName}[]`
+    // System collections use singular (non-array) entries so MergeCoreCollection in the SDK
+    // can find the key and merge custom fields into readUsers() / readSettings() / etc.
+    // https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
+    const valueType = (isSingleton || isDirectusSystemCollection) ? interfaceName : `${interfaceName}[]`
     return `\t${collection.collection}: ${valueType};`
   })
 

--- a/test/generate-types.test.ts
+++ b/test/generate-types.test.ts
@@ -99,7 +99,7 @@ describe('generateTypesFromDirectus()', () => {
   // valid/suggested call on the generated client because the Directus REST
   // API does not serve system collections from /items/*.
   describe('system collections', () => {
-    it('are omitted from the DirectusSchema map', async () => {
+    it('are present in DirectusSchema as singular (non-array) entries', async () => {
       mockDirectusRequest().directusVersion('latest')
       const result = await generateTypesFromDirectus('http://localhost', 'admin', 'App')
 
@@ -107,7 +107,16 @@ describe('generateTypesFromDirectus()', () => {
       // directus_* strings that appear in unrelated interface bodies.
       const schemaBlock = result.typeString.match(/interface DirectusSchema \{([\s\S]*?)\n\}/)
       expect(schemaBlock, 'DirectusSchema interface should be emitted').not.toBeNull()
-      expect(schemaBlock![1]).not.toMatch(/\bdirectus_\w+\s*:/)
+
+      // Every directus_* entry must be singular (no trailing []) so that
+      // MergeCoreCollection in the SDK can find the key and merge custom fields,
+      // while RegularCollections<Schema> excludes them (keeping readItems() clean).
+      const body = schemaBlock![1]
+      const systemEntries = [...body.matchAll(/\bdirectus_\w+\s*:\s*(\S+);/g)]
+      expect(systemEntries.length, 'at least one directus_* entry should be present').toBeGreaterThan(0)
+      for (const [, valueType] of systemEntries) {
+        expect(valueType, `system collection entry should not be an array type`).not.toMatch(/\[\]$/)
+      }
     })
 
     it('are omitted from the CollectionNames enum', async () => {

--- a/test/known-issues-upstream.test-d.ts
+++ b/test/known-issues-upstream.test-d.ts
@@ -1,0 +1,26 @@
+// FIXME: THESE TESTS DON'T ACTUALLY RUN UNTIL #72 IS ADDRESSED
+
+/**
+ * Type-level tests for known upstream bugs.
+ *
+ * Tests in this file PASS while the upstream bug exists and FAIL once it is
+ * fixed — that failure is the signal to delete the test.
+ */
+import { readSingleton } from '@directus/sdk'
+import { describe, it } from 'vitest'
+import { useDirectus } from '../src/runtime/composables/directus'
+
+describe('known issues upstream', () => {
+  /**
+   * Bug: https://github.com/directus/directus/pull/27196
+   *
+   * `readSingleton` should only accept user-defined singleton collections, but
+   * currently also accepts system collection names like `'directus_settings'`.
+   * This test passes while the bug exists. When the upstream fix ships,
+   * `readSingleton('directus_settings')` will become a type error here —
+   * delete this test at that point.
+   */
+  it('readSingleton incorrectly accepts system collection "directus_settings" [delete when fixed]', () => {
+    useDirectus().request(readSingleton('directus_settings'))
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
           name: 'default',
           include: ['test/**/*.test.ts'],
           exclude: ['test/url-helpers.server.test.ts', 'test/url-helpers.client.test.ts'],
+          // typecheck: {
+          //   enabled: true,
+          //   checker: 'vue-tsc',
+          //   include: ['test/**/*.test-d.ts'],
+          // },
         },
       },
     ],


### PR DESCRIPTION
This is on top of your current PR #68. If you approve of these changes merge into your PR before merging your PR to next.

This fully addresses the recommendations here:
https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections

There is an upstream bug https://github.com/directus/directus/issues/27195 and I submitted a PR to hopefully fix it https://github.com/directus/directus/pull/27196

The bug is really not any serious risk, the impact is related to type checking for readSingleton(); there is no error currently when you pass a core collection (directus_*) to readSingleton. It has and still throws an error in runtime.

Note that because we don't have vue-tsc in the project, the test I wrote isn't actually active, but I committed it so that it will be once vue-tsc is implemented.