### PR TITLE
clarify `updateMe()` in auth composable types and fix return types for auth composable.

### DIFF
--- a/docs/api/composables/auth.md
+++ b/docs/api/composables/auth.md
@@ -15,12 +15,12 @@ interface DirectusAuth {
   user: Ref<DirectusUsers | null>
   loggedIn: ComputedRef<boolean>
   readMe: () => Promise<DirectusUsers | null>
-  updateMe: (data: Partial<DirectusUsers>) => Promise<DirectusUsers | null>
+  updateMe: (data: UpdateMeInput) => Promise<DirectusUsers>
   login: (email: string, password: string, options?: LoginOptions & { redirect?: boolean | RouteLocationRaw }) => Promise<DirectusUsers | null>
   loginWithProvider: (provider: string, redirectOnLogin?: boolean | string) => Promise<void>
   logout: (redirect?: boolean | RouteLocationRaw) => Promise<void>
-  createUser: (data: Partial<DirectusUsers>) => Promise<DirectusUsers>
-  register: (data: Partial<DirectusUsers>) => Promise<DirectusUsers>
+  createUser: (data: RegisterUserInput) => Promise<DirectusUsers>
+  register: (data: RegisterUserInput) => Promise<DirectusUsers>
   inviteUser: (email: string, role: string, inviteUrl?: string) => Promise<void>
   acceptUserInvite: (token: string, password: string) => Promise<void>
   passwordRequest: (email: string, resetUrl?: string) => Promise<void>
@@ -101,9 +101,9 @@ const user = await readMe()
 Update the current user's profile.
 
 **Parameters:**
-- `data: Partial<DirectusUsers>` - Fields to update
+- `data: UpdateMeInput` - Fields to update. `role` and `policies` are excluded to prevent privilege escalation. `avatar` accepts a pre-uploaded file ID (`string`), not a file object — upload the file first, then pass its ID here.
 
-**Returns:** `Promise<DirectusUsers | null>`
+**Returns:** `Promise<DirectusUsers>`
 
 ```typescript
 const { updateMe } = useDirectusAuth()
@@ -111,8 +111,10 @@ const { updateMe } = useDirectusAuth()
 await updateMe({
   first_name: 'John',
   last_name: 'Doe',
-  avatar: 'file-uuid',
 })
+
+// To update avatar, first upload the file, then attach its ID
+await updateMe({ avatar: 'file-uuid' })
 ```
 
 ##### `login(email, password, options?)`
@@ -192,7 +194,7 @@ await logout('/login')
 Create a new user account. `register()` is an alias for `createUser()`.
 
 **Parameters:**
-- `data: Partial<DirectusUsers>` - User data
+- `data: RegisterUserInput` - User registration data
 
 **Returns:** `Promise<DirectusUsers>`
 

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -319,7 +319,7 @@ Returns an object with auth methods and state:
 const {
   user, // Ref<DirectusUser | null>
   loggedIn, // ComputedRef<boolean>
-  readMe, // () => Promise<DirectusUser>
+  readMe, // () => Promise<DirectusUser | null>
   updateMe, // (data) => Promise<DirectusUser>
   login, // (email, password, options?) => Promise<DirectusUser>
   loginWithProvider, // (provider, redirect?) => Promise<void>

--- a/src/module.ts
+++ b/src/module.ts
@@ -275,12 +275,15 @@ export default defineNuxtModule<ModuleOptions>({
     },
   },
   async setup(options, nuxtApp) {
+    // set up array to send logs in messagebox
+    const loggerMessage: string[] = []
+
     // Resolve client and server URLs from the url option
     const clientUrl = typeof options.url === 'string' ? options.url : options.url?.client
     const serverUrl = typeof options.url === 'string' ? options.url : options.url?.server
 
     if (!clientUrl) {
-      logger.warn('No Directus URL found at build time. Set it in config options, .env file as DIRECTUS_URL, or at runtime via NUXT_PUBLIC_DIRECTUS_URL.')
+      loggerMessage.push(`⚠️ No Directus URL found at build time:`, `  - Set it in config options, .env file as DIRECTUS_URL or at runtime via NUXT_PUBLIC_DIRECTUS_URL.`, '')
     }
 
     const resolver = createResolver(import.meta.url)
@@ -294,8 +297,6 @@ export default defineNuxtModule<ModuleOptions>({
         (nuxtApp.options as any)[key] = defu((nuxtApp.options as any)[key], moduleOptions)
       }
     }
-    // set up array to send logs in messagebox
-    const loggerMessage: string[] = []
 
     // Normalize devProxy options
     const devProxyConfig = typeof options.devProxy === 'boolean'
@@ -396,7 +397,7 @@ export default defineNuxtModule<ModuleOptions>({
         wsPath: wsProxyPath,
       }
     }
-    else if (!nuxtApp.options.dev) {
+    else if (!nuxtApp.options.dev && directusUrl) {
       loggerMessage.push(`🌐 Production Mode:`, `  - SDK connects directly to ${colors.dim(`${directusUrl}`)}`, '')
       options.devProxy = false
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import type { Query } from '@directus/sdk'
+import type { DirectusUser, Query } from '@directus/sdk'
 import type { ImageModifiers, ImageProviders } from '@nuxt/image'
 import type { InlinePreset } from 'unimport'
 
@@ -13,7 +13,7 @@ import { useUrl } from './runtime/utils'
 import { discoverSdkImports } from './sdk-imports'
 
 export type DirectusUrl = string | { client: string, server: string }
-export type ReadMeFields = Query<DirectusSchema, DirectusSchema['directus_users']>['fields']
+export type ReadMeFields = Query<DirectusSchema, DirectusUser<DirectusSchema>>['fields']
 
 export interface ModuleOptions {
   /**

--- a/src/runtime/composables/auth.ts
+++ b/src/runtime/composables/auth.ts
@@ -1,10 +1,7 @@
 import type { ComputedRef, Ref } from '#imports'
 import type { RouteLocationRaw } from '#vue-router'
-import type { LoginOptions } from '@directus/sdk'
-import type {
-  DirectusError,
-  RegisterUserInput,
-} from '@directus/types'
+import type { DirectusUser as DirectusUserSDK, LoginOptions, NestedPartial } from '@directus/sdk'
+import type { RegisterUserInput } from '@directus/types'
 import { navigateTo, useRouter, useRuntimeConfig } from '#app'
 import { computed, useRequestURL, useState } from '#imports'
 import {
@@ -19,17 +16,31 @@ import {
 import { joinURL, withoutTrailingSlash } from 'ufo'
 import { useDirectus, useDirectusOriginUrl } from './directus'
 
-// Auto types don't seem to be generating correctly here, so we need to specify the return type
+/**
+ * Fields that can be passed to {@link useDirectusAuth.updateMe}.
+ *
+ * `role` and `policies` are intentionally excluded — users cannot elevate their
+ * own privileges via this composable.
+ *
+ * `avatar` accepts a pre-uploaded file ID (`string`). To change a user's avatar,
+ * first upload the file via the files endpoint to get its ID, then pass that ID here.
+ */
+export type UpdateMeInput = Omit<NestedPartial<DirectusUserSDK<DirectusSchema>>, 'id' | 'role' | 'policies' | 'avatar'> & {
+  avatar?: string | null
+}
+
+// Field selection is driven by runtime config (`readMeFields`), so TypeScript cannot
+// infer return types from the SDK generics. This interface is the explicit public contract.
 export interface DirectusAuth {
   user: Ref<DirectusUser | null>
   loggedIn: ComputedRef<boolean>
-  readMe: () => Promise<DirectusUser | DirectusError | null>
-  updateMe: (data: Partial<DirectusUser>) => Promise<DirectusUser | DirectusError | null>
+  readMe: () => Promise<DirectusUser | null>
+  updateMe: (data: UpdateMeInput) => Promise<DirectusUser>
   login: (email: string, password: string, options?: LoginOptions & { redirect?: boolean | RouteLocationRaw }) => Promise<DirectusUser | null>
   loginWithProvider: (provider: string, redirectOnLogin?: boolean | string) => Promise<void>
   logout: (redirect?: boolean | RouteLocationRaw) => Promise<void>
-  createUser: (data: RegisterUserInput & Partial<Omit<DirectusUser, 'id' | 'email' | 'password'>>) => Promise<DirectusUser>
-  register: (data: RegisterUserInput & Partial<Omit<DirectusUser, 'id' | 'email' | 'password'>>) => Promise<DirectusUser>
+  createUser: (data: RegisterUserInput) => Promise<DirectusUser>
+  register: (data: RegisterUserInput) => Promise<DirectusUser>
   inviteUser: (email: string, role: string, inviteUrl?: string | undefined) => Promise<void>
   acceptUserInvite: (token: string, password: string) => Promise<void>
   passwordRequest: (email: string, resetUrl?: string | undefined) => Promise<void>
@@ -62,7 +73,8 @@ export function useDirectusAuth(): DirectusAuth {
     loading.value = true
 
     try {
-      const response = await directus.request(directusReadMe({ fields: (config.public.directus.auth?.readMeFields ?? ['*']) as any }))
+      const fields = config.public.directus.auth?.readMeFields
+      const response = await directus.request(directusReadMe(fields?.length ? { fields: fields as any } : undefined))
       if (!response.id) {
         console.warn('Directus is not configured to return the \'id\' field for DirectusUsers.')
       }
@@ -78,17 +90,16 @@ export function useDirectusAuth(): DirectusAuth {
 
     return user.value
   }
-  // FIXME: Avatar requires a separated upload and/or ability to apply Object or string -> Possible Solution is to chunk into uploadDirectusFile -> Attach 'id' string to data.avatar UpdateMe call.
-  // FIXME: Role and Policies will work, but due to the Omit won't get type safety (Previous implementation also didn't have typesafety for them but now it's explicit.)
-  async function updateMe(data: Partial<Omit<DirectusUser, 'avatar' | 'role' | 'policies'>>) {
+  async function updateMe(data: UpdateMeInput): Promise<DirectusUser> {
     const currentUser = user.value
 
     if (!currentUser?.id)
       throw new Error('No user available')
-    // INVESTIGATE: Does this cause issues with creative inputs in the config? Config won't have typesafety so probably a heavy lift for a low return.
-    const response = await directus.request(directusUpdateMe(data as any, { fields: (config.public.directus.auth?.readMeFields ?? ['*']) as any }))
+
+    const fields = config.public.directus.auth?.readMeFields
+    const response = await directus.request(directusUpdateMe(data, fields?.length ? { fields: fields as any } : undefined))
     user.value = response as unknown as DirectusUser
-    return user.value
+    return user.value!
   }
 
   async function login(email: string, password: string, options?: Omit<LoginOptions, 'mode'> & { redirect?: boolean | RouteLocationRaw }) {

--- a/src/runtime/composables/files.ts
+++ b/src/runtime/composables/files.ts
@@ -1,5 +1,5 @@
 import type { DirectusFile, DirectusSchema } from '#build/types/directus'
-import type { Query } from '@directus/sdk'
+import type { DirectusFile as DirectusSdkFile, Query } from '@directus/sdk'
 import { uploadFiles } from '@directus/sdk'
 import { useDirectus, useDirectusUrl } from './directus'
 
@@ -8,13 +8,13 @@ interface DirectusFileUpload {
   data?: Record<keyof DirectusFile, string>
 }
 
-export async function uploadDirectusFile(file: DirectusFileUpload, query?: Query<DirectusSchema, DirectusSchema['directus_files']>) {
+export async function uploadDirectusFile(file: DirectusFileUpload, query?: Query<DirectusSchema, DirectusSdkFile<DirectusSchema>>) {
   const result = await uploadDirectusFiles([file], query)
 
   return (Array.isArray(result) ? result[0] : result)
 }
 
-export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Query<DirectusSchema, DirectusSchema['directus_files']>) {
+export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Query<DirectusSchema, DirectusSdkFile<DirectusSchema>>) {
   const directus = useDirectus()
   const formData = new FormData()
 
@@ -28,7 +28,7 @@ export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Q
     formData.append('file', file)
   })
 
-  return directus.request(uploadFiles(formData, query as any)) as unknown as DirectusFile[] | DirectusFile
+  return directus.request(uploadFiles(formData, query)) as unknown as DirectusFile[] | DirectusFile
 }
 
 export type DirectusThumbnailFormat = 'jpg' | 'png' | 'webp' | 'tiff' | 'avif'

--- a/src/runtime/types/fallback.d.ts
+++ b/src/runtime/types/fallback.d.ts
@@ -1,5 +1,6 @@
-export interface FallbackSchema {
-  directus_users?: Record<string, never>
-}
+export {}
 
-declare global { interface DirectusSchema extends FallbackSchema { } }
+declare global {
+  interface DirectusSchema {
+  }
+}

--- a/src/runtime/types/generate.ts
+++ b/src/runtime/types/generate.ts
@@ -296,11 +296,23 @@ export function transformSnapshotToTypeString(
 
   const customInterfaceBlocks = generatedCollections.map(g => g.interfaceBlock)
 
-  // TODO: Review what happens if DirectusSchema omits the directus_ system collections
-  const directusSchemaBlock = generateDirectusSchemaInterface(allCollectionsForSchema, prefix, singletonCollectionNames)
+  // Omit directus_* entries from the DirectusSchema map. The SDK already
+  // merges its own CoreSchema (every directus_* collection) into the client
+  // via CompleteSchema, so readMe / readUsers / readFiles / etc. still
+  // resolve against DirectusUser<Schema> and friends and pick up user-level
+  // customisations from the separately-emitted `interface DirectusUser {}`
+  // augmentations. Keeping directus_* in DirectusSchema only causes
+  // `readItems('directus_users')` to be suggested, which fails at runtime
+  // because system collections are not served from /items/*. See #65.
+  const schemaMapCollections = allCollectionsForSchema.filter(
+    c => !collectionIsDirectusSystem(c.collection),
+  )
+  const directusSchemaBlock = generateDirectusSchemaInterface(schemaMapCollections, prefix, singletonCollectionNames)
 
-  // TODO: Review what happens if enum omits the directus_ system collections
-  const allCollectionNames = allCollectionsForSchema.map(c => c.collection)
+  // The enum is user-facing sugar for iterating custom collection names, so
+  // it follows the same filter — consumers using it to build UI lists don't
+  // want `directus_activity` showing up in a dropdown.
+  const allCollectionNames = schemaMapCollections.map(c => c.collection)
   const enumBlock = generateCollectionNamesEnum(allCollectionNames, prefix)
 
   const bodyParts = [

--- a/src/runtime/types/generate.ts
+++ b/src/runtime/types/generate.ts
@@ -296,23 +296,17 @@ export function transformSnapshotToTypeString(
 
   const customInterfaceBlocks = generatedCollections.map(g => g.interfaceBlock)
 
-  // Omit directus_* entries from the DirectusSchema map. The SDK already
-  // merges its own CoreSchema (every directus_* collection) into the client
-  // via CompleteSchema, so readMe / readUsers / readFiles / etc. still
-  // resolve against DirectusUser<Schema> and friends and pick up user-level
-  // customisations from the separately-emitted `interface DirectusUser {}`
-  // augmentations. Keeping directus_* in DirectusSchema only causes
-  // `readItems('directus_users')` to be suggested, which fails at runtime
-  // because system collections are not served from /items/*. See #65.
-  const schemaMapCollections = allCollectionsForSchema.filter(
-    c => !collectionIsDirectusSystem(c.collection),
-  )
-  const directusSchemaBlock = generateDirectusSchemaInterface(schemaMapCollections, prefix, singletonCollectionNames)
+  // System collections are emitted as non-array (singular) entries in DirectusSchema so that
+  // MergeCoreCollection<Schema, "directus_settings", ...> in the SDK can find the key and merge
+  // any custom fields into the return types.
+  // See: https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
+  const directusSchemaBlock = generateDirectusSchemaInterface(allCollectionsForSchema, prefix, singletonCollectionNames)
 
-  // The enum is user-facing sugar for iterating custom collection names, so
-  // it follows the same filter — consumers using it to build UI lists don't
-  // want `directus_activity` showing up in a dropdown.
-  const allCollectionNames = schemaMapCollections.map(c => c.collection)
+  // The enum is user-facing sugar for iterating custom collection names
+  // consumers using it to build UI lists don't want `directus_activity` showing up in a dropdown.
+  const allCollectionNames = allCollectionsForSchema
+    .filter(c => !collectionIsDirectusSystem(c.collection))
+    .map(c => c.collection)
   const enumBlock = generateCollectionNamesEnum(allCollectionNames, prefix)
 
   const bodyParts = [
@@ -749,8 +743,12 @@ function generateDirectusSchemaInterface(
 ): string {
   const entries = allCollections.map((collection) => {
     const isSingleton = collection.meta?.singleton === true
+    const isDirectusSystemCollection = collectionIsDirectusSystem(collection.collection)
     const interfaceName = collectionNameToInterfaceName(collection.collection, prefix, singletons)
-    const valueType = isSingleton ? interfaceName : `${interfaceName}[]`
+    // System collections use singular (non-array) entries so MergeCoreCollection in the SDK
+    // can find the key and merge custom fields into readUsers() / readSettings() / etc.
+    // https://directus.io/docs/tutorials/tips-and-tricks/advanced-types-with-the-directus-sdk#custom-fields-on-core-collections
+    const valueType = (isSingleton || isDirectusSystemCollection) ? interfaceName : `${interfaceName}[]`
     return `\t${collection.collection}: ${valueType};`
   })
 

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from 'vitest'
+
+/**
+ * Pending tests for useDirectusAuth and useDirectusUser composables @ src/runtime/composables/auth.ts
+ *
+ * Mocking requirements:
+ *   - '#app': navigateTo, useRouter, useRuntimeConfig
+ *   - '#imports': computed, useRequestURL, useState
+ *   - './directus': useDirectus, useDirectusOriginUrl
+ *   - '@directus/sdk': readMe, updateMe, createUser, inviteUser, acceptUserInvite, passwordRequest, passwordReset
+ *
+ * Note that some of the functions in the auth composable don't have catch blocks and that should probably be considerd
+ *
+ * TODO: Address in issue #63
+ * https://github.com/rolleyio/nuxt-directus-sdk/issues/63
+ */
+
+describe('useDirectusUser', () => {
+  it.todo('returns a Ref<DirectusUser | null> backed by useState key "directus.user"')
+})
+
+describe('useDirectusAuth', () => {
+  describe('readMe', () => {
+    it.todo('fetches the current user and sets user.value on success')
+    it.todo('returns null and sets user.value = null when the SDK throws')
+    it.todo('logs a warning when the response does not include an id field')
+    it.todo('prevents concurrent calls — second call while loading returns current user.value without re-fetching')
+    it.todo('passes configured readMeFields as fields query when non-empty')
+    it.todo('passes no fields query when readMeFields is empty (SDK default returns all fields)')
+  })
+
+  describe('updateMe', () => {
+    it.todo('throws "No user available" when user.value is null')
+    it.todo('throws "No user available" when user.value has no id')
+    it.todo('updates user.value with the SDK response and returns it')
+    it.todo('passes configured readMeFields as fields query when non-empty')
+    it.todo('passes no fields query when readMeFields is empty')
+  })
+
+  describe('login', () => {
+    it.todo('calls directus.login with mode: session and then readMe')
+    it.todo('redirects to auth.redirect.home by default after login')
+    it.todo('redirects to the query.redirect param when present')
+    it.todo('redirects to the provided RouteLocationRaw when redirect option is a non-boolean')
+    it.todo('does not redirect when redirect option is false')
+    it.todo('returns the current user after login')
+  })
+
+  describe('loginWithProvider', () => {
+    it.todo('navigates externally to the Directus SSO endpoint with encoded redirect URL')
+    it.todo('uses auth.redirect.login as redirect path when redirectOnLogin is true')
+    it.todo('uses current href as redirect path when redirectOnLogin is false')
+    it.todo('uses the provided string as redirect path when redirectOnLogin is a string')
+    it.todo('strips trailing slash from the redirect URL')
+  })
+
+  describe('logout', () => {
+    it.todo('calls directus.logout and clears user.value')
+    it.todo('clears user.value even when directus.logout throws')
+    it.todo('redirects to auth.redirect.logout after logout by default')
+    it.todo('falls back to auth.redirect.login when logout redirect is not configured')
+    it.todo('redirects to the provided RouteLocationRaw when given')
+    it.todo('does not redirect when redirect is false')
+  })
+
+  describe('createUser / register', () => {
+    it.todo('createUser forwards RegisterUserInput to the SDK and returns the created user')
+    it.todo('register is an alias for createUser and produces the same result')
+  })
+
+  describe('inviteUser', () => {
+    it.todo('calls the SDK inviteUser with email, role, and optional inviteUrl')
+  })
+
+  describe('acceptUserInvite', () => {
+    it.todo('calls the SDK acceptUserInvite with token and password')
+  })
+
+  describe('passwordRequest', () => {
+    it.todo('calls the SDK passwordRequest with email and optional resetUrl')
+  })
+
+  describe('passwordReset', () => {
+    it.todo('calls the SDK passwordReset with token and password')
+  })
+})

--- a/test/generate-types.test.ts
+++ b/test/generate-types.test.ts
@@ -99,7 +99,7 @@ describe('generateTypesFromDirectus()', () => {
   // valid/suggested call on the generated client because the Directus REST
   // API does not serve system collections from /items/*.
   describe('system collections', () => {
-    it('are omitted from the DirectusSchema map', async () => {
+    it('are present in DirectusSchema as singular (non-array) entries', async () => {
       mockDirectusRequest().directusVersion('latest')
       const result = await generateTypesFromDirectus('http://localhost', 'admin', 'App')
 
@@ -107,7 +107,16 @@ describe('generateTypesFromDirectus()', () => {
       // directus_* strings that appear in unrelated interface bodies.
       const schemaBlock = result.typeString.match(/interface DirectusSchema \{([\s\S]*?)\n\}/)
       expect(schemaBlock, 'DirectusSchema interface should be emitted').not.toBeNull()
-      expect(schemaBlock![1]).not.toMatch(/\bdirectus_\w+\s*:/)
+
+      // Every directus_* entry must be singular (no trailing []) so that
+      // MergeCoreCollection in the SDK can find the key and merge custom fields,
+      // while RegularCollections<Schema> excludes them (keeping readItems() clean).
+      const body = schemaBlock![1]
+      const systemEntries = [...body.matchAll(/\bdirectus_\w+\s*:\s*(\S+);/g)]
+      expect(systemEntries.length, 'at least one directus_* entry should be present').toBeGreaterThan(0)
+      for (const [, valueType] of systemEntries) {
+        expect(valueType, `system collection entry should not be an array type`).not.toMatch(/\[\]$/)
+      }
     })
 
     it('are omitted from the CollectionNames enum', async () => {

--- a/test/generate-types.test.ts
+++ b/test/generate-types.test.ts
@@ -95,6 +95,42 @@ describe('generateTypesFromDirectus()', () => {
     })
   })
 
+  // Regression guard for #65: readItems('directus_users') should not be a
+  // valid/suggested call on the generated client because the Directus REST
+  // API does not serve system collections from /items/*.
+  describe('system collections', () => {
+    it('are omitted from the DirectusSchema map', async () => {
+      mockDirectusRequest().directusVersion('latest')
+      const result = await generateTypesFromDirectus('http://localhost', 'admin', 'App')
+
+      // Extract just the DirectusSchema interface body so we don't match
+      // directus_* strings that appear in unrelated interface bodies.
+      const schemaBlock = result.typeString.match(/interface DirectusSchema \{([\s\S]*?)\n\}/)
+      expect(schemaBlock, 'DirectusSchema interface should be emitted').not.toBeNull()
+      expect(schemaBlock![1]).not.toMatch(/\bdirectus_\w+\s*:/)
+    })
+
+    it('are omitted from the CollectionNames enum', async () => {
+      mockDirectusRequest().directusVersion('latest')
+      const result = await generateTypesFromDirectus('http://localhost', 'admin', 'App')
+
+      const enumBlock = result.typeString.match(/enum AppCollectionNames \{([\s\S]*?)\n\}/)
+      expect(enumBlock, 'AppCollectionNames enum should be emitted').not.toBeNull()
+      expect(enumBlock![1]).not.toMatch(/\bdirectus_\w+\s*=/)
+    })
+
+    it('still emit their own interface declarations so readMe / readUsers keep working', async () => {
+      mockDirectusRequest().directusVersion('latest')
+      const result = await generateTypesFromDirectus('http://localhost', 'admin', 'App')
+
+      // The SDK's CoreSchema is augmented via `interface DirectusUser {}`,
+      // so these blocks must still be emitted even when the schema map
+      // drops the directus_* keys.
+      expect(result.typeString).toMatch(/interface DirectusUser\s*\{/)
+      expect(result.typeString).toMatch(/interface DirectusFile\s*\{/)
+    })
+  })
+
   describe('applies jsdoc comments', () => {
     it('for @primaryKey', async () => {
       mockDirectusRequest().directusVersion('latest')

--- a/test/known-issues-upstream.test-d.ts
+++ b/test/known-issues-upstream.test-d.ts
@@ -1,0 +1,26 @@
+// FIXME: THESE TESTS DON'T ACTUALLY RUN UNTIL #72 IS ADDRESSED
+
+/**
+ * Type-level tests for known upstream bugs.
+ *
+ * Tests in this file PASS while the upstream bug exists and FAIL once it is
+ * fixed — that failure is the signal to delete the test.
+ */
+import { readSingleton } from '@directus/sdk'
+import { describe, it } from 'vitest'
+import { useDirectus } from '../src/runtime/composables/directus'
+
+describe('known issues upstream', () => {
+  /**
+   * Bug: https://github.com/directus/directus/pull/27196
+   *
+   * `readSingleton` should only accept user-defined singleton collections, but
+   * currently also accepts system collection names like `'directus_settings'`.
+   * This test passes while the bug exists. When the upstream fix ships,
+   * `readSingleton('directus_settings')` will become a type error here —
+   * delete this test at that point.
+   */
+  it('readSingleton incorrectly accepts system collection "directus_settings" [delete when fixed]', () => {
+    useDirectus().request(readSingleton('directus_settings'))
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
           name: 'default',
           include: ['test/**/*.test.ts'],
           exclude: ['test/url-helpers.server.test.ts', 'test/url-helpers.client.test.ts'],
+          // typecheck: {
+          //   enabled: true,
+          //   checker: 'vue-tsc',
+          //   include: ['test/**/*.test-d.ts'],
+          // },
         },
       },
     ],


### PR DESCRIPTION
This PR builds on #68 and #73 -- review and push those first, if there are recommended changes in those PRs I will need to revisit this one. There will be quite a few unlocks and fixes as a result of those two PRs in more accurately typing returns. 😄 

- Introduces type `UpdateMeInput` as a subset of NestedPartial<DirectusUser<DirectusSchema>> to make privilege boundaries explicit:
  - role and policies are excluded to prevent self-escalation
  - avatar is narrowed to string | null (pre-uploaded file ID only).
- Corrects readMe and updateMe return types in DirectusAuth: removes the phantom DirectusError union from readMe (errors are caught internally) and removes | null from updateMe (it throws, never returns null).
- Removes a dead ?? ['*'] fallback because the default readMeFields is [], which the SDK drops from query params, so omitting the query entirely is both simpler and produces the correct inferred return type through the SDK generics.
- Updates createUser/register signatures to RegisterUserInput, matching the implementation.
- Docs updated to reflect all of the above, with avatar two-step flow clarified.
- fixes #70 

Note, in reviewing the SDK there is a:
- `registerUser()` function [See Code](https://github.com/directus/directus/blob/8fdc6ce7b907b99cb55da4f2d6b34dda5344c088/sdk/src/rest/commands/utils/users.ts#L52-66)
- `createUser()` and `createUsers()` functions  [See Code](https://github.com/directus/directus/blob/8fdc6ce7b907b99cb55da4f2d6b34dda5344c088/sdk/src/rest/commands/create/users.ts#L19-L49)

Our module treats them both the same, but I believe one is for public consumption and one is for admin. I'll need to do more research on this to get the implementation right and there's nobody clamoring for a fix here so I might just defer the problem - let me know if you have any thoughts the `register` v `create` or have any knowledge of the difference that I am not getting at a glance.

THIS IS A DRAFT REQUEST AS I AM HOPING YOU WILL REVIEW #68 and #73 before looking at this. it depends on those two PRs.