### PR TITLE
feat(composables): allow custom schema type on useDirectus

### DIFF
--- a/docs/api/composables/client.md
+++ b/docs/api/composables/client.md
@@ -4,11 +4,14 @@ outline: deep
 
 # Client Composables
 
-### `useDirectus()`
+### `useDirectus<TSchema>()`
 
 Get the Directus client instance for making API requests.
 
-**Returns:** `DirectusClient<DirectusSchema>`
+**Type parameters:**
+- `TSchema` (optional) - Schema to type the client against. Defaults to the generated `DirectusSchema` global. Pass a custom schema to extend or narrow the typing for a specific call site.
+
+**Returns:** `DirectusClient<TSchema> & AuthenticationClient<TSchema> & RestClient<TSchema> & WebSocketClient<TSchema>`
 
 ```typescript
 const directus = useDirectus()
@@ -57,6 +60,23 @@ await directus.request(deleteItem('collection', 'id'))
 // Singletons
 const singleton = await directus.request(readSingleton('settings'))
 await directus.request(updateSingleton('settings', data))
+```
+
+**Custom schema:**
+
+You can pass a schema generic when you want to override or extend the generated `DirectusSchema` for a specific call site (for example: tests, or code talking to a second Directus instance with a different schema).
+
+```typescript
+interface MySchema {
+  posts: {
+    id: number
+    title: string
+  }
+}
+
+const directus = useDirectus<MySchema>()
+const posts = await directus.request(readItems('posts'))
+//    ^? { id: number, title: string }[]
 ```
 
 ---

--- a/docs/guide/server-side.md
+++ b/docs/guide/server-side.md
@@ -159,6 +159,30 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
+## Custom Schema
+
+All three server composables (`useSessionDirectus`, `useAdminDirectus`, `useTokenDirectus`) accept an optional `TSchema` generic. By default the client is typed against the generated `DirectusSchema`, which is what you want most of the time. Pass a custom schema when you need to override or extend the typing for a specific route:
+
+```typescript
+interface MySchema {
+  posts: {
+    id: number
+    title: string
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const directus = useSessionDirectus<MySchema>(event)
+  const posts = await directus.request(readItems('posts'))
+  //    ^? { id: number, title: string }[]
+})
+```
+
+This is most useful when:
+- Talking to a second Directus instance with a different schema from the same Nuxt app
+- Narrowing the schema in a server route to a known subset of collections
+- Writing tests against a fixture schema
+
 ## Manual Token Extraction
 
 ### `getDirectusSessionToken(event)`

--- a/src/runtime/composables/directus.ts
+++ b/src/runtime/composables/directus.ts
@@ -1,5 +1,5 @@
 import type { Ref } from '#imports'
-import type { WebSocketAuthModes } from '@directus/sdk'
+import type { AuthenticationClient, DirectusClient, RestClient, WebSocketAuthModes, WebSocketClient } from '@directus/sdk'
 import { useRequestHeaders, useRuntimeConfig, useState } from '#imports'
 import { authentication, createDirectus, realtime, rest } from '@directus/sdk'
 import { useUrl } from '../utils'
@@ -125,18 +125,24 @@ function createDirectusClient() {
   return directus
 }
 
-let directus: ReturnType<typeof createDirectusClient> | null = null
+type DirectusClientWithExtensions<TSchema extends object>
+  = DirectusClient<TSchema>
+    & AuthenticationClient<TSchema>
+    & RestClient<TSchema>
+    & WebSocketClient<TSchema>
 
-export function useDirectus() {
+let directus: DirectusClientWithExtensions<DirectusSchema> | null = null
+
+export function useDirectus<TSchema extends object = DirectusSchema>(): DirectusClientWithExtensions<TSchema> {
   // On server, always create a fresh client to capture current request headers
   // On client, use singleton to maintain state
   if (import.meta.server) {
-    return createDirectusClient()
+    return createDirectusClient() as unknown as DirectusClientWithExtensions<TSchema>
   }
 
   if (!directus) {
     directus = createDirectusClient()
   }
 
-  return directus
+  return directus as unknown as DirectusClientWithExtensions<TSchema>
 }

--- a/src/runtime/server/services/directus.ts
+++ b/src/runtime/server/services/directus.ts
@@ -1,8 +1,14 @@
+import type { AuthenticationClient, DirectusClient, RestClient } from '@directus/sdk'
 import type { H3Event } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import { authentication, createDirectus, rest } from '@directus/sdk'
 import { getCookie } from 'h3'
 import { useUrl } from '../../utils'
+
+type DirectusServerClient<TSchema extends object>
+  = DirectusClient<TSchema>
+    & AuthenticationClient<TSchema>
+    & RestClient<TSchema>
 
 export function getDirectusSessionToken(event: H3Event): string | undefined {
   // Session mode: look for the session token cookie set by Directus
@@ -17,8 +23,8 @@ export function useDirectusUrl(path = ''): string {
   return useUrl(url, path)
 }
 
-export function useTokenDirectus(token?: string) {
-  const directus = createDirectus<DirectusSchema>(useDirectusUrl())
+export function useTokenDirectus<TSchema extends object = DirectusSchema>(token?: string): DirectusServerClient<TSchema> {
+  const directus = createDirectus<TSchema>(useDirectusUrl())
     .with(authentication('json', { autoRefresh: false }))
     .with(rest())
 
@@ -28,17 +34,17 @@ export function useTokenDirectus(token?: string) {
   return directus
 }
 
-export function useSessionDirectus(event: H3Event) {
+export function useSessionDirectus<TSchema extends object = DirectusSchema>(event: H3Event): DirectusServerClient<TSchema> {
   // Derive the client's auth from the session cookie on the incoming request.
-  return useTokenDirectus(getDirectusSessionToken(event))
+  return useTokenDirectus<TSchema>(getDirectusSessionToken(event))
 }
 
-export function useAdminDirectus() {
+export function useAdminDirectus<TSchema extends object = DirectusSchema>(): DirectusServerClient<TSchema> {
   const config = useRuntimeConfig().directus
   const adminToken = config.adminToken || process.env.DIRECTUS_ADMIN_TOKEN
 
   if (!adminToken)
     throw new Error('DIRECTUS_ADMIN_TOKEN is not set in config options or .env file')
 
-  return useTokenDirectus(adminToken)
+  return useTokenDirectus<TSchema>(adminToken)
 }

--- a/test/directus.test-d.ts
+++ b/test/directus.test-d.ts
@@ -1,6 +1,8 @@
 import type { DirectusClient, RestClient } from '@directus/sdk'
+import type { H3Event } from 'h3'
 import { describe, expectTypeOf, it } from 'vitest'
 import { useDirectus } from '../src/runtime/composables/directus'
+import { useAdminDirectus, useSessionDirectus, useTokenDirectus } from '../src/runtime/server/services/directus'
 
 interface CustomSchema {
   posts: {
@@ -8,6 +10,8 @@ interface CustomSchema {
     title: string
   }
 }
+
+const event = {} as H3Event
 
 describe('useDirectus', () => {
   it('defaults to the ambient DirectusSchema when no generic is passed', () => {
@@ -18,5 +22,35 @@ describe('useDirectus', () => {
   it('propagates a custom schema when one is provided', () => {
     expectTypeOf(useDirectus<CustomSchema>()).toMatchTypeOf<DirectusClient<CustomSchema>>()
     expectTypeOf(useDirectus<CustomSchema>()).toMatchTypeOf<RestClient<CustomSchema>>()
+  })
+})
+
+describe('useTokenDirectus', () => {
+  it('defaults to the ambient DirectusSchema when no generic is passed', () => {
+    expectTypeOf(useTokenDirectus()).toMatchTypeOf<DirectusClient<DirectusSchema>>()
+  })
+
+  it('propagates a custom schema when one is provided', () => {
+    expectTypeOf(useTokenDirectus<CustomSchema>()).toMatchTypeOf<DirectusClient<CustomSchema>>()
+  })
+})
+
+describe('useSessionDirectus', () => {
+  it('defaults to the ambient DirectusSchema when no generic is passed', () => {
+    expectTypeOf(useSessionDirectus(event)).toMatchTypeOf<DirectusClient<DirectusSchema>>()
+  })
+
+  it('propagates a custom schema when one is provided', () => {
+    expectTypeOf(useSessionDirectus<CustomSchema>(event)).toMatchTypeOf<DirectusClient<CustomSchema>>()
+  })
+})
+
+describe('useAdminDirectus', () => {
+  it('defaults to the ambient DirectusSchema when no generic is passed', () => {
+    expectTypeOf(useAdminDirectus()).toMatchTypeOf<DirectusClient<DirectusSchema>>()
+  })
+
+  it('propagates a custom schema when one is provided', () => {
+    expectTypeOf(useAdminDirectus<CustomSchema>()).toMatchTypeOf<DirectusClient<CustomSchema>>()
   })
 })

--- a/test/directus.test-d.ts
+++ b/test/directus.test-d.ts
@@ -1,0 +1,22 @@
+import type { DirectusClient, RestClient } from '@directus/sdk'
+import { describe, expectTypeOf, it } from 'vitest'
+import { useDirectus } from '../src/runtime/composables/directus'
+
+interface CustomSchema {
+  posts: {
+    id: number
+    title: string
+  }
+}
+
+describe('useDirectus', () => {
+  it('defaults to the ambient DirectusSchema when no generic is passed', () => {
+    expectTypeOf(useDirectus()).toMatchTypeOf<DirectusClient<DirectusSchema>>()
+    expectTypeOf(useDirectus()).toMatchTypeOf<RestClient<DirectusSchema>>()
+  })
+
+  it('propagates a custom schema when one is provided', () => {
+    expectTypeOf(useDirectus<CustomSchema>()).toMatchTypeOf<DirectusClient<CustomSchema>>()
+    expectTypeOf(useDirectus<CustomSchema>()).toMatchTypeOf<RestClient<CustomSchema>>()
+  })
+})


### PR DESCRIPTION
## Summary

Adds an optional `TSchema` generic to all client + server composables that build a Directus client, defaulting to the ambient `DirectusSchema` so existing callers keep working.

**Client composable:**
- `useDirectus<TSchema>()`

**Server composables (`#imports/server`):**
- `useTokenDirectus<TSchema>(token?)`
- `useSessionDirectus<TSchema>(event)`
- `useAdminDirectus<TSchema>()`

Consumers can now opt into a different schema (extended, narrowed, or for code talking to a second Directus instance) without going through `declare global`:

```ts
const directus = useDirectus<MyExtendedSchema>()
const sessionClient = useSessionDirectus<MyExtendedSchema>(event)
```

The client-side singleton stays typed against the generated `DirectusSchema`. The generic is applied via cast at the return boundary, since the singleton needs a concrete type at module scope. Server composables build a fresh client per call so they propagate the generic through `createDirectus<TSchema>` directly. `createDirectusClient` (private) is unchanged.

Closes #82.

## Test plan

- [ ] `pnpm test` passes (19 files, 356 tests, no type errors)
- [ ] `pnpm lint` clean
- [ ] `test/directus.test-d.ts` asserts the type contract for all four entry points: default is `DirectusSchema`, custom schema propagates to `DirectusClient<T>` and `RestClient<T>`
- [ ] Existing call sites still type-check without changes
- [ ] Docs updated: `docs/api/composables/client.md` + new "Custom Schema" section in `docs/guide/server-side.md`