### PR TITLE
chore: update domain references to nuxt-directus-sdk.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 > A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.
 
 - [✨ &nbsp;Release Notes](https://github.com/rolleyio/nuxt-directus-sdk/releases)
-- [📚 &nbsp;Documentation](https://nuxt-directus-sdk.rolley.io)
-- [🛝 &nbsp;Live Playground](https://playground.nuxt-directus-sdk.rolley.io)
+- [📚 &nbsp;Documentation](https://www.nuxt-directus-sdk.com)
+- [🛝 &nbsp;Live Playground](https://playground.nuxt-directus-sdk.com)
 
 ## Features
 
@@ -64,11 +64,11 @@ DIRECTUS_URL=https://your-directus-url.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token # Optional: required for type generation
 ```
 
-4. **Configure your Directus backend** for cross-domain authentication (see the [Authentication Guide](https://nuxt-directus-sdk.rolley.io/guide/authentication.html))
+4. **Configure your Directus backend** for cross-domain authentication (see the [Authentication Guide](https://www.nuxt-directus-sdk.com/guide/authentication.html))
 
 That's it! You can now use Directus within your Nuxt app ✨
 
-For cross-domain setups (e.g. `app.example.com` and `api.example.com`), see the [Authentication Guide](https://nuxt-directus-sdk.rolley.io/guide/authentication.html).
+For cross-domain setups (e.g. `app.example.com` and `api.example.com`), see the [Authentication Guide](https://www.nuxt-directus-sdk.com/guide/authentication.html).
 
 ## CLI
 
@@ -85,7 +85,7 @@ npx nuxt-directus-sdk rules:pull -o rules.json
 npx nuxt-directus-sdk --help
 ```
 
-See the [CLI documentation](https://nuxt-directus-sdk.rolley.io/api/configuration/module#types) for flags and examples.
+See the [CLI documentation](https://www.nuxt-directus-sdk.com/api/configuration/module#types) for flags and examples.
 
 ## Development
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   title: 'Nuxt Directus SDK',
   description: 'The best way to integrate Directus with Nuxt - featuring authentication, realtime, file management, and more',
   sitemap: {
-    hostname: 'https://nuxt-directus-sdk.rolley.io',
+    hostname: 'https://www.nuxt-directus-sdk.com',
   },
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "description": "A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.",
   "author": "Matthew Rollinson <matt@rolley.io>",
   "license": "MIT",
-  "homepage": "https://nuxt-directus-sdk.rolley.io",
+  "homepage": "https://www.nuxt-directus-sdk.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/rolleyio/nuxt-directus-sdk"


### PR DESCRIPTION
## Summary

Replaces stale `nuxt-directus-sdk.rolley.io` references with the new domain set:

- `https://www.nuxt-directus-sdk.com` (docs site)
- `https://playground.nuxt-directus-sdk.com` (live playground)

The `rolley.io` URLs redirect, so nothing was broken — this is just hygiene so the source-of-truth URLs match the new domain.

## Changes

- `README.md` — docs + playground links, plus three in-body links to the authentication and CLI docs
- `package.json` — `homepage` field
- `docs/.vitepress/config.ts` — sitemap `hostname`

## Intentionally left alone

- `CHANGELOG.md` — historical record, not rewriting
- `package.json` `author` email (`matt@rolley.io`) — unrelated to the website
- `playground/.env` — gitignored, local-only

## Test plan

- [ ] Links in README render correctly on GitHub
- [ ] Sitemap regenerates with new hostname on next docs build