### PR TITLE
feat(proxy): allow devProxy in production (HTTP only) and harden cookie rewriter

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
           { text: 'File Management', link: '/guide/files' },
           { text: 'Visual Editor', link: '/guide/visual-editor' },
           { text: 'Type Generation', link: '/guide/type-generation' },
-          { text: 'Dev Proxy', link: '/guide/dev-proxy' },
+          { text: 'Proxy', link: '/guide/proxy' },
           { text: 'Server-Side Utils', link: '/guide/server-side' },
         ],
       },

--- a/docs/api/composables/client.md
+++ b/docs/api/composables/client.md
@@ -76,14 +76,14 @@ Generate full URLs to your Directus instance. This composable is context-aware:
 
 ```typescript
 const directusUrl = useDirectusUrl()
-// Client: https://cms.example.com
+// Client: https://directus.example.com
 // Server (with split URL): http://directus:8055
 
 const apiUrl = useDirectusUrl('items/articles')
-// Client: https://cms.example.com/items/articles
+// Client: https://directus.example.com/items/articles
 
 const assetsUrl = useDirectusUrl('assets')
-// Client: https://cms.example.com/assets
+// Client: https://directus.example.com/assets
 ```
 
 ---
@@ -101,10 +101,10 @@ Use this when you need the real Directus URL for browser navigation (e.g. SSO re
 
 ```typescript
 const ssoUrl = useDirectusOriginUrl('/auth/login/google?redirect=...')
-// Always: https://cms.example.com/auth/login/google?redirect=...
+// Always: https://directus.example.com/auth/login/google?redirect=...
 
 const adminUrl = useDirectusOriginUrl('admin')
-// Always: https://cms.example.com/admin
+// Always: https://directus.example.com/admin
 ```
 
 ---

--- a/docs/api/composables/client.md
+++ b/docs/api/composables/client.md
@@ -65,9 +65,9 @@ await directus.request(updateSingleton('settings', data))
 
 Generate full URLs to your Directus instance. This composable is context-aware:
 
-- **Client**: returns the client URL (or proxy path if `devProxy` is enabled)
+- **Client**: returns the client URL (or proxy path if `proxy` is enabled)
 - **Server (SSR)**: returns the server URL if configured (for Docker/K8s internal networking), otherwise the client URL
-- **Dev proxy**: returns `window.location.origin + proxyPath` on client, or host header-based URL on server
+- **Proxy**: returns `window.location.origin + proxyPath` on client, or host header-based URL on server
 
 **Parameters:**
 - `path?: string` - Optional path to append
@@ -90,7 +90,7 @@ const assetsUrl = useDirectusUrl('assets')
 
 ### `useDirectusOriginUrl(path?)`
 
-Generate URLs to the **public-facing** Directus instance. Unlike `useDirectusUrl`, this always returns the client URL — it ignores both `devProxy` and `serverDirectusUrl`.
+Generate URLs to the **public-facing** Directus instance. Unlike `useDirectusUrl`, this always returns the client URL; it ignores both `proxy` and `serverDirectusUrl`.
 
 Use this when you need the real Directus URL for browser navigation (e.g. SSO redirects, admin links).
 

--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -186,8 +186,8 @@ export default defineNuxtConfig({
 })
 ```
 
-::: tip Renamed from `devProxy`
-The option was previously called `devProxy`. The old name still works as an alias but logs a deprecation warning at build time. See the [Proxy guide](/guide/proxy#migration-from-devproxy) for migration details.
+::: tip Renamed from `devProxy` in v6.1
+The option was previously called `devProxy`. From v6.1 the old name still works as an alias but logs a deprecation warning at build time; it will be removed in the next major release. See the [Proxy guide](/guide/proxy#migration-from-devproxy) for migration details.
 :::
 
 #### `devtools`

--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -44,7 +44,7 @@ export default defineNuxtConfig({
     adminToken: process.env.DIRECTUS_ADMIN_TOKEN,
 
     // Development
-    devProxy: {
+    proxy: {
       enabled: true,
       path: '/directus',
       wsPath: '/directus-ws',
@@ -146,46 +146,49 @@ DIRECTUS_ADMIN_TOKEN=your-admin-token-here
 
 **Security Note:** Never commit admin tokens to version control. Always use environment variables.
 
-### Development Options
+### Proxy Options
 
-#### `devProxy`
+#### `proxy`
 
 - **Type:** `boolean | { enabled?: boolean, path?: string, wsPath?: string }`
 - **Default:** `{ enabled: true, path: '/directus', wsPath: '/directus-ws' }` in dev mode
 - **Default:** `false` in production
 
-Development proxy configuration. When enabled, creates a proxy that forwards requests to your Directus instance, eliminating CORS issues and supporting dynamic ports.
+Proxy configuration. When enabled, creates a Nitro server handler that forwards HTTP requests to your Directus instance, eliminating CORS issues and supporting dynamic ports in development. In production it solves cross-domain cookie scope problems (e.g. login on Vercel where app and Directus are on different domains).
 
 ```typescript
 export default defineNuxtConfig({
   directus: {
     // Simple boolean
-    devProxy: true,
+    proxy: true,
 
     // Or detailed configuration
-    devProxy: {
+    proxy: {
       enabled: true,
       path: '/directus', // HTTP proxy mount path
-      wsPath: '/directus-ws', // WebSocket proxy path (optional)
+      wsPath: '/directus-ws', // WebSocket proxy path (dev only)
     },
   },
 })
 ```
 
 **How it works:**
-- In development: Requests automatically route through the proxy using the current port
-- Supports Nuxt's dynamic port changes (e.g., port 3000 → 3001)
-- In production: Direct connection to Directus URL
-- WebSocket proxy available at `wsPath` for realtime features
+- In development: requests route through the proxy on Nuxt's current port. Supports dynamic port changes (3000 → 3001).
+- In production: off by default. Set `proxy: true` (or `{ enabled: true }`) to enable HTTP proxying.
+- WebSocket proxy at `wsPath` is dev-only. In production, realtime connects directly to Directus.
 
 **Disable proxy:**
 ```typescript
 export default defineNuxtConfig({
   directus: {
-    devProxy: false, // Use direct connection in dev
+    proxy: false, // Use direct connection in dev
   },
 })
 ```
+
+::: tip Renamed from `devProxy`
+The option was previously called `devProxy`. The old name still works as an alias but logs a deprecation warning at build time. See the [Proxy guide](/guide/proxy#migration-from-devproxy) for migration details.
+:::
 
 #### `devtools`
 

--- a/docs/guide/dev-proxy.md
+++ b/docs/guide/dev-proxy.md
@@ -111,6 +111,36 @@ With this set, the module registers a Nitro server handler at `/directus/**` in 
 
 If you need realtime with auth in production-with-proxy, the cleanest answer is usually to put Directus on a subdomain of your app (`api.example.com` and `app.example.com`) with `SESSION_COOKIE_DOMAIN=.example.com`, so cookies are shared without proxying.
 
+## Client IP & `IP_TRUST_PROXY`
+
+When the proxy is on, every request reaches Directus from your **Nuxt server's** IP. The connection is Nuxt to Directus, not browser to Directus. The real client IP travels in the `X-Forwarded-For` header, and the proxy sets it to a single, resolved value rather than blindly forwarding whatever the browser sent. This matters only if your Directus instance uses an IP-based feature:
+
+- Role/policy **IP allow-lists** (`ip_access`)
+- **Per-IP rate limiting** (`RATE_LIMITER_*`)
+- The client IP recorded in the **activity / audit log**
+
+For Directus to read that header it has to trust the proxy, which it controls with `IP_TRUST_PROXY`:
+
+- **Directus 11 and earlier** defaulted to `IP_TRUST_PROXY=true`; it trusts `X-Forwarded-For` out of the box, so the proxy "just worked".
+- **Directus 12+** changed the default to `false` to harden against IP spoofing ([directus#27607](https://github.com/directus/directus/pull/27607)). With the new default, Directus ignores `X-Forwarded-For`, so every proxied request looks like it came from your Nuxt server.
+
+If you run the proxy **and** rely on client IPs on Directus 12+, set it to trust exactly one hop, the SDK proxy:
+
+```bash
+# Directus .env
+IP_TRUST_PROXY=1
+```
+
+Prefer the hop count (`1`) over a blanket `true`. The SDK proxy already strips the attacker-controllable inbound header and forwards a single clean entry, so trusting one hop gives you the real client IP without re-opening the spoofing hole that `true` is prone to. If you stack another proxy in front of your Nuxt app (e.g. Cloudflare → Nuxt → Directus), increase the count to match.
+
+::: tip Direct mode is unaffected
+This section only applies when the proxy is enabled. With `devProxy: false`, browsers talk to Directus directly and it sees the real client IP from the connection itself; `IP_TRUST_PROXY` then only concerns whatever proxy sits in front of Directus.
+:::
+
+::: warning Resolution is only as trustworthy as your edge
+The proxy resolves the client IP from the request reaching your Nuxt server. If Nuxt is exposed directly to the internet with no trusted edge in front of it, that value can itself be spoofed. Configure your platform / Nitro trust settings so the incoming IP is trustworthy before relying on it downstream.
+:::
+
 ## See Also
 
 - [Module option: `devProxy`](/api/configuration/module#devproxy)

--- a/docs/guide/dev-proxy.md
+++ b/docs/guide/dev-proxy.md
@@ -86,9 +86,30 @@ Or disable just the WebSocket proxy by leaving `enabled: true` and setting `wsPa
 
 ## Production Behaviour
 
-In production builds, the proxy is off by default and all requests go directly to the `client` URL from the browser. This is what you want: no extra hop, no Nuxt server involvement for Directus calls. Cookie domains need to match (either same apex domain or configured correctly) for session auth to work; see the [Authentication guide](/guide/authentication) for the cross-domain setup.
+In production builds the proxy is off by default and all requests go directly to the `client` URL from the browser. This is what most users want: no extra hop, no Nuxt server involvement on every Directus call. For this to work with session auth, cookie domains have to match — either same apex domain or configured correctly. See the [Authentication guide](/guide/authentication) for the cross-domain setup.
 
-You can force the proxy on in production with `devProxy: { enabled: true }`, but this is unusual and generally not recommended; the proxy adds a hop every call makes through your Nuxt server.
+### Enabling the proxy in production
+
+Sometimes the direct-from-browser route doesn't work. The most common case is hosting Directus on a different domain than your Nuxt app where you can't (or don't want to) deal with cross-domain cookies — third-party cookie restrictions in modern browsers make this increasingly fragile, especially in staging environments. Turning the proxy on in production puts the session cookie back on your own origin:
+
+```ts
+export default defineNuxtConfig({
+  directus: {
+    url: process.env.NUXT_PUBLIC_DIRECTUS_URL,
+    devProxy: { enabled: true }, // or just `devProxy: true`
+  },
+})
+```
+
+With this set, the module registers a Nitro server handler at `/directus/**` in your production build that forwards HTTP requests to Directus, preserving cookies on your own domain.
+
+**Trade-offs to know about:**
+
+- **Extra hop on every Directus call.** Browser → your Nuxt server → Directus instead of browser → Directus. Negligible for occasional calls like login; can add up on data-heavy pages.
+- **WebSocket proxy is dev-only.** The realtime proxy uses the Nuxt dev-server's upgrade hook, which doesn't exist in production builds. If you turn the HTTP proxy on in production, realtime connects directly to Directus instead — which means realtime is still subject to the original cross-domain cookie problem if you're using `realtimeAuthMode: 'handshake'` or `'strict'`. For `'public'` realtime (no auth), this is fine.
+- **Serverless caveats.** On platforms like Vercel functions or Netlify functions, the HTTP proxy works (regular request/response). WebSocket proxying wouldn't work even if we could enable it — those runtimes don't hold persistent connections.
+
+If you need realtime with auth in production-with-proxy, the cleanest answer is usually to put Directus on a subdomain of your app (`api.example.com` and `app.example.com`) with `SESSION_COOKIE_DOMAIN=.example.com`, so cookies are shared without proxying.
 
 ## See Also
 

--- a/docs/guide/dev-proxy.md
+++ b/docs/guide/dev-proxy.md
@@ -1,148 +1,19 @@
-# Development Proxy
+---
+title: Dev Proxy (moved)
+description: This page has moved to /guide/proxy.
+---
 
-In development, the module creates a proxy at `/directus` that forwards requests from your Nuxt dev server to Directus. This eliminates CORS issues, handles cookie forwarding for session auth, and proxies WebSocket connections for realtime.
+<script setup>
+import { onMounted } from 'vue'
 
-## Default Behaviour
-
-The proxy is **enabled by default in development** and **disabled in production**. Most users don't need to configure anything.
-
-```typescript
-// nuxt.config.ts, zero config needed
-export default defineNuxtConfig({
-  modules: ['nuxt-directus-sdk'],
-  directus: {
-    url: process.env.DIRECTUS_URL,
-  },
+onMounted(() => {
+  // Client-side redirect for users who hit the old URL.
+  window.location.replace('/guide/proxy')
 })
-```
+</script>
 
-Browser requests that would normally go to `https://your-directus.com/items/posts` instead go to `http://localhost:3000/directus/items/posts` and the Nuxt dev server forwards them.
+# Dev Proxy → Proxy
 
-The proxy automatically picks up Nuxt's port, including dynamic port changes (3000 → 3001 when you already have a server running).
+This page has moved to **[/guide/proxy](/guide/proxy)**. The option was renamed from `devProxy` to `proxy` to reflect that it works in production builds too. You'll be redirected automatically.
 
-## Configuration
-
-```typescript
-export default defineNuxtConfig({
-  directus: {
-    devProxy: {
-      enabled: true, // default: true in dev, false in prod
-      path: '/directus', // HTTP proxy mount path
-      wsPath: '/directus-ws', // WebSocket proxy path (for realtime)
-    },
-  },
-})
-```
-
-- **`enabled`** (`boolean`, default: `true` in dev, `false` in prod) — turns the proxy on or off.
-- **`path`** (`string`, default: `/directus`) — the URL path prefix the proxy mounts under.
-- **`wsPath`** (`string`, default: `/directus-ws`) — separate path for WebSocket connections. Kept separate from `path` because the HTTP handler can't also terminate a WebSocket upgrade cleanly.
-
-**Shorthand:** pass a boolean to enable/disable with defaults.
-
-```typescript
-export default defineNuxtConfig({
-  directus: {
-    devProxy: true, // same as { enabled: true }
-  },
-})
-```
-
-```typescript
-export default defineNuxtConfig({
-  directus: {
-    devProxy: false, // disable, use the direct URL even in dev
-  },
-})
-```
-
-## Why It Exists
-
-Three problems it solves:
-
-1. **CORS.** Your Nuxt dev server is on `http://localhost:3000`. Directus is on `https://your-directus.com`. Without the proxy, every browser request is cross-origin and needs CORS headers configured on Directus. With the proxy, requests are same-origin.
-2. **Cookies.** Session-based authentication relies on httpOnly cookies. Cookies are scoped to the domain that sets them, so a `Set-Cookie` from Directus wouldn't be honoured by a browser fetching from `localhost`. The proxy rewrites the cookie domain so the cookie is accepted.
-3. **WebSockets.** Realtime subscriptions use the WebSocket protocol, which has its own handshake and CORS rules. The `wsPath` proxy handles this with cookie forwarding so auth survives the upgrade.
-
-## Works with Split URLs
-
-If you've set up separate `client` and `server` URLs (for Docker, Kubernetes, or any setup where your Nuxt server reaches Directus via an internal hostname), the dev proxy forwards to the `server` URL and exposes it under the proxy path to the browser. Same-origin for the browser, internal hostname for the backend, no special handling on your end.
-
-See the [`url` option reference](/api/configuration/module#url) for split-URL configuration.
-
-## Disabling the Proxy
-
-If you want browsers to talk to Directus directly even in development (for instance, you've configured CORS on Directus and prefer real URLs in DevTools Network panel), disable the proxy:
-
-```typescript
-export default defineNuxtConfig({
-  directus: {
-    devProxy: false,
-  },
-})
-```
-
-Or disable just the WebSocket proxy by leaving `enabled: true` and setting `wsPath: false` (HTTP proxy on, realtime goes direct).
-
-## Production Behaviour
-
-In production builds the proxy is off by default and all requests go directly to the `client` URL from the browser. This is what most users want: no extra hop, no Nuxt server involvement on every Directus call. For this to work with session auth, cookie domains have to match — either same apex domain or configured correctly. See the [Authentication guide](/guide/authentication) for the cross-domain setup.
-
-### Enabling the proxy in production
-
-Sometimes the direct-from-browser route doesn't work. The most common case is hosting Directus on a different domain than your Nuxt app where you can't (or don't want to) deal with cross-domain cookies — third-party cookie restrictions in modern browsers make this increasingly fragile, especially in staging environments. Turning the proxy on in production puts the session cookie back on your own origin:
-
-```ts
-export default defineNuxtConfig({
-  directus: {
-    url: process.env.NUXT_PUBLIC_DIRECTUS_URL,
-    devProxy: { enabled: true }, // or just `devProxy: true`
-  },
-})
-```
-
-With this set, the module registers a Nitro server handler at `/directus/**` in your production build that forwards HTTP requests to Directus, preserving cookies on your own domain.
-
-**Trade-offs to know about:**
-
-- **Extra hop on every Directus call.** Browser → your Nuxt server → Directus instead of browser → Directus. Negligible for occasional calls like login; can add up on data-heavy pages.
-- **WebSocket proxy is dev-only.** The realtime proxy uses the Nuxt dev-server's upgrade hook, which doesn't exist in production builds. If you turn the HTTP proxy on in production, realtime connects directly to Directus instead — which means realtime is still subject to the original cross-domain cookie problem if you're using `realtimeAuthMode: 'handshake'` or `'strict'`. For `'public'` realtime (no auth), this is fine.
-- **Serverless caveats.** On platforms like Vercel functions or Netlify functions, the HTTP proxy works (regular request/response). WebSocket proxying wouldn't work even if we could enable it — those runtimes don't hold persistent connections.
-
-If you need realtime with auth in production-with-proxy, the cleanest answer is usually to put Directus on a subdomain of your app (`api.example.com` and `app.example.com`) with `SESSION_COOKIE_DOMAIN=.example.com`, so cookies are shared without proxying.
-
-## Client IP & `IP_TRUST_PROXY`
-
-When the proxy is on, every request reaches Directus from your **Nuxt server's** IP. The connection is Nuxt to Directus, not browser to Directus. The real client IP travels in the `X-Forwarded-For` header, and the proxy sets it to a single, resolved value rather than blindly forwarding whatever the browser sent. This matters only if your Directus instance uses an IP-based feature:
-
-- Role/policy **IP allow-lists** (`ip_access`)
-- **Per-IP rate limiting** (`RATE_LIMITER_*`)
-- The client IP recorded in the **activity / audit log**
-
-For Directus to read that header it has to trust the proxy, which it controls with `IP_TRUST_PROXY`:
-
-- **Directus 11 and earlier** defaulted to `IP_TRUST_PROXY=true`; it trusts `X-Forwarded-For` out of the box, so the proxy "just worked".
-- **Directus 12+** changed the default to `false` to harden against IP spoofing ([directus#27607](https://github.com/directus/directus/pull/27607)). With the new default, Directus ignores `X-Forwarded-For`, so every proxied request looks like it came from your Nuxt server.
-
-If you run the proxy **and** rely on client IPs on Directus 12+, set it to trust exactly one hop, the SDK proxy:
-
-```bash
-# Directus .env
-IP_TRUST_PROXY=1
-```
-
-Prefer the hop count (`1`) over a blanket `true`. The SDK proxy already strips the attacker-controllable inbound header and forwards a single clean entry, so trusting one hop gives you the real client IP without re-opening the spoofing hole that `true` is prone to. If you stack another proxy in front of your Nuxt app (e.g. Cloudflare → Nuxt → Directus), increase the count to match.
-
-::: tip Direct mode is unaffected
-This section only applies when the proxy is enabled. With `devProxy: false`, browsers talk to Directus directly and it sees the real client IP from the connection itself; `IP_TRUST_PROXY` then only concerns whatever proxy sits in front of Directus.
-:::
-
-::: warning Resolution is only as trustworthy as your edge
-The proxy resolves the client IP from the request reaching your Nuxt server. If Nuxt is exposed directly to the internet with no trusted edge in front of it, that value can itself be spoofed. Configure your platform / Nitro trust settings so the incoming IP is trustworthy before relying on it downstream.
-:::
-
-## See Also
-
-- [Module option: `devProxy`](/api/configuration/module#devproxy)
-- [Module option: `url`](/api/configuration/module#url)
-- [Authentication guide: cross-domain setups](/guide/authentication)
+See the [migration section](/guide/proxy#migration-from-devproxy) for details.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -113,6 +113,6 @@ Now that you're set up, explore the features:
 - [File Management](/guide/files) - Upload and transform files
 - [Visual Editor](/guide/visual-editor) - Live preview and inline editing
 - [Type Generation](/guide/type-generation) - Auto-generated types from your Directus schema
-- [Proxy](/guide/proxy) - CORS-free local development
+- [Proxy](/guide/proxy) - Support for cross origin server configurations
 - [Server-Side Utils](/guide/server-side) - Server routes and utilities
 - [Configuration Reference](/api/configuration/) - All configuration options

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -113,6 +113,6 @@ Now that you're set up, explore the features:
 - [File Management](/guide/files) - Upload and transform files
 - [Visual Editor](/guide/visual-editor) - Live preview and inline editing
 - [Type Generation](/guide/type-generation) - Auto-generated types from your Directus schema
-- [Dev Proxy](/guide/dev-proxy) - CORS-free local development
+- [Proxy](/guide/proxy) - CORS-free local development
 - [Server-Side Utils](/guide/server-side) - Server routes and utilities
 - [Configuration Reference](/api/configuration/) - All configuration options

--- a/docs/guide/proxy.md
+++ b/docs/guide/proxy.md
@@ -1,0 +1,170 @@
+# Proxy
+
+The module can create a proxy at `/directus` that forwards requests from your Nuxt server to Directus. This eliminates CORS issues, handles cookie forwarding for session auth, and (in dev) proxies WebSocket connections for realtime.
+
+::: tip Renamed from `devProxy`
+The option was originally called `devProxy` because it only worked in development. It now works in production builds too, so the name has been generalised to `proxy`. The old name still works as an alias but logs a deprecation warning. Rename your config at your convenience.
+:::
+
+## Default Behaviour
+
+The proxy is **enabled by default in development** and **disabled in production**. Most users don't need to configure anything.
+
+```typescript
+// nuxt.config.ts, zero config needed
+export default defineNuxtConfig({
+  modules: ['nuxt-directus-sdk'],
+  directus: {
+    url: process.env.DIRECTUS_URL,
+  },
+})
+```
+
+Browser requests that would normally go to `https://your-directus.com/items/posts` instead go to `http://localhost:3000/directus/items/posts` and the Nuxt server forwards them.
+
+The proxy automatically picks up Nuxt's port, including dynamic port changes (3000 → 3001 when you already have a server running).
+
+## Configuration
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    proxy: {
+      enabled: true, // default: true in dev, false in prod
+      path: '/directus', // HTTP proxy mount path
+      wsPath: '/directus-ws', // WebSocket proxy path (for realtime)
+    },
+  },
+})
+```
+
+- **`enabled`** (`boolean`, default: `true` in dev, `false` in prod). Turns the proxy on or off.
+- **`path`** (`string`, default: `/directus`). The URL path prefix the proxy mounts under.
+- **`wsPath`** (`string`, default: `/directus-ws`). Separate path for WebSocket connections. Kept separate from `path` because the HTTP handler can't also terminate a WebSocket upgrade cleanly.
+
+**Shorthand:** pass a boolean to enable/disable with defaults.
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    proxy: true, // same as { enabled: true }
+  },
+})
+```
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    proxy: false, // disable, use the direct URL even in dev
+  },
+})
+```
+
+## Why It Exists
+
+Three problems it solves:
+
+1. **CORS.** Your Nuxt dev server is on `http://localhost:3000`. Directus is on `https://your-directus.com`. Without the proxy, every browser request is cross-origin and needs CORS headers configured on Directus. With the proxy, requests are same-origin.
+2. **Cookies.** Session-based authentication relies on httpOnly cookies. Cookies are scoped to the domain that sets them, so a `Set-Cookie` from Directus wouldn't be honoured by a browser fetching from `localhost`. The proxy rewrites the cookie domain so the cookie is accepted.
+3. **WebSockets.** Realtime subscriptions use the WebSocket protocol, which has its own handshake and CORS rules. The `wsPath` proxy handles this with cookie forwarding so auth survives the upgrade.
+
+## Works with Split URLs
+
+If you've set up separate `client` and `server` URLs (for Docker, Kubernetes, or any setup where your Nuxt server reaches Directus via an internal hostname), the proxy forwards to the `server` URL and exposes it under the proxy path to the browser. Same-origin for the browser, internal hostname for the backend, no special handling on your end.
+
+See the [`url` option reference](/api/configuration/module#url) for split-URL configuration.
+
+## Disabling the Proxy
+
+If you want browsers to talk to Directus directly even in development (for instance, you've configured CORS on Directus and prefer real URLs in DevTools Network panel), disable the proxy:
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    proxy: false,
+  },
+})
+```
+
+Or disable just the WebSocket proxy by leaving `enabled: true` and setting `wsPath: false` (HTTP proxy on, realtime goes direct).
+
+## Production Behaviour
+
+In production builds the proxy is off by default and all requests go directly to the `client` URL from the browser. This is what most users want: no extra hop, no Nuxt server involvement on every Directus call. For this to work with session auth, cookie domains have to match, either same apex domain or configured correctly. See the [Authentication guide](/guide/authentication) for the cross-domain setup.
+
+### Enabling the proxy in production
+
+Sometimes the direct-from-browser route doesn't work. The most common case is hosting Directus on a different domain than your Nuxt app where you can't (or don't want to) deal with cross-domain cookies. Third-party cookie restrictions in modern browsers make this increasingly fragile, especially in staging environments. Turning the proxy on in production puts the session cookie back on your own origin:
+
+```ts
+export default defineNuxtConfig({
+  directus: {
+    url: process.env.NUXT_PUBLIC_DIRECTUS_URL,
+    proxy: { enabled: true }, // or just `proxy: true`
+  },
+})
+```
+
+With this set, the module registers a Nitro server handler at `/directus/**` in your production build that forwards HTTP requests to Directus, preserving cookies on your own domain.
+
+**Trade-offs to know about:**
+
+- **Extra hop on every Directus call.** Browser to your Nuxt server to Directus instead of browser to Directus. Negligible for occasional calls like login; can add up on data-heavy pages.
+- **WebSocket proxy is dev-only.** The realtime proxy uses the Nuxt dev-server's upgrade hook, which doesn't exist in production builds. If you turn the HTTP proxy on in production, realtime connects directly to Directus instead, which means realtime is still subject to the original cross-domain cookie problem if you're using `realtimeAuthMode: 'handshake'` or `'strict'`. For `'public'` realtime (no auth), this is fine.
+- **Serverless caveats.** On platforms like Vercel functions or Netlify functions, the HTTP proxy works (regular request/response). WebSocket proxying wouldn't work even if we could enable it; those runtimes don't hold persistent connections.
+
+If you need realtime with auth in production-with-proxy, the cleanest answer is usually to put Directus on a subdomain of your app (`api.example.com` and `app.example.com`) with `SESSION_COOKIE_DOMAIN=.example.com`, so cookies are shared without proxying.
+
+## Client IP & `IP_TRUST_PROXY`
+
+When the proxy is on, every request reaches Directus from your **Nuxt server's** IP. The connection is Nuxt to Directus, not browser to Directus. The real client IP travels in the `X-Forwarded-For` header, and the proxy sets it to a single, resolved value rather than blindly forwarding whatever the browser sent. This matters only if your Directus instance uses an IP-based feature:
+
+- Role/policy **IP allow-lists** (`ip_access`)
+- **Per-IP rate limiting** (`RATE_LIMITER_*`)
+- The client IP recorded in the **activity / audit log**
+
+For Directus to read that header it has to trust the proxy, which it controls with `IP_TRUST_PROXY`:
+
+- **Directus 11 and earlier** defaulted to `IP_TRUST_PROXY=true`; it trusts `X-Forwarded-For` out of the box, so the proxy "just worked".
+- **Directus 12+** changed the default to `false` to harden against IP spoofing ([directus#27607](https://github.com/directus/directus/pull/27607)). With the new default, Directus ignores `X-Forwarded-For`, so every proxied request looks like it came from your Nuxt server.
+
+If you run the proxy **and** rely on client IPs on Directus 12+, set it to trust exactly one hop, the SDK proxy:
+
+```bash
+# Directus .env
+IP_TRUST_PROXY=1
+```
+
+Prefer the hop count (`1`) over a blanket `true`. The SDK proxy already strips the attacker-controllable inbound header and forwards a single clean entry, so trusting one hop gives you the real client IP without re-opening the spoofing hole that `true` is prone to. If you stack another proxy in front of your Nuxt app (e.g. Cloudflare to Nuxt to Directus), increase the count to match.
+
+::: tip Direct mode is unaffected
+This section only applies when the proxy is enabled. With `proxy: false`, browsers talk to Directus directly and it sees the real client IP from the connection itself; `IP_TRUST_PROXY` then only concerns whatever proxy sits in front of Directus.
+:::
+
+::: warning Resolution is only as trustworthy as your edge
+The proxy resolves the client IP from the request reaching your Nuxt server. If Nuxt is exposed directly to the internet with no trusted edge in front of it, that value can itself be spoofed. Configure your platform / Nitro trust settings so the incoming IP is trustworthy before relying on it downstream.
+:::
+
+## Migration from `devProxy`
+
+The option was renamed from `devProxy` to `proxy` to reflect that it works in production too. The old name still works as an alias:
+
+```ts
+// Old (deprecated, still works with a warning)
+directus: {
+  devProxy: { enabled: true },
+}
+
+// New (preferred)
+directus: {
+  proxy: { enabled: true },
+}
+```
+
+If both `proxy` and `devProxy` are set, `proxy` wins and `devProxy` is ignored. The runtime config is published under the `proxy` key only, so the deprecated name doesn't leak into your app's runtime.
+
+## See Also
+
+- [Module option: `proxy`](/api/configuration/module#proxy)
+- [Module option: `url`](/api/configuration/module#url)
+- [Authentication guide: cross-domain setups](/guide/authentication)

--- a/docs/guide/proxy.md
+++ b/docs/guide/proxy.md
@@ -1,8 +1,8 @@
 # Proxy
 
-The module can create a proxy at `/directus` that forwards requests from your Nuxt server to Directus. This eliminates CORS issues, handles cookie forwarding for session auth, and (in dev) proxies WebSocket connections for realtime.
+The module can create a proxy path to Directus at a user defined frontend path (defaults to `/directus`). This eliminates CORS issues, handles cookie forwarding for session auth, and (in dev) proxies WebSocket connections for realtime.
 
-::: tip Renamed from `devProxy`
+::: tip Renamed from `devProxy` in v6.1
 The option was originally called `devProxy` because it only worked in development. It now works in production builds too, so the name has been generalised to `proxy`. The old name still works as an alias but logs a deprecation warning. Rename your config at your convenience.
 :::
 
@@ -20,7 +20,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Browser requests that would normally go to `https://your-directus.com/items/posts` instead go to `http://localhost:3000/directus/items/posts` and the Nuxt server forwards them.
+Browser requests that would normally go to `https://directus.example.com/items/posts` instead go to `http://localhost:3000/directus/items/posts` and the Nuxt server forwards them.
 
 The proxy automatically picks up Nuxt's port, including dynamic port changes (3000 → 3001 when you already have a server running).
 
@@ -64,7 +64,7 @@ export default defineNuxtConfig({
 
 Three problems it solves:
 
-1. **CORS.** Your Nuxt dev server is on `http://localhost:3000`. Directus is on `https://your-directus.com`. Without the proxy, every browser request is cross-origin and needs CORS headers configured on Directus. With the proxy, requests are same-origin.
+1. **CORS.** Your Nuxt dev server is on `http://localhost:3000`. Directus is on `https://directus.example.com`. Without the proxy, every browser request is cross-origin and needs CORS headers configured on Directus. With the proxy, requests are same-origin.
 2. **Cookies.** Session-based authentication relies on httpOnly cookies. Cookies are scoped to the domain that sets them, so a `Set-Cookie` from Directus wouldn't be honoured by a browser fetching from `localhost`. The proxy rewrites the cookie domain so the cookie is accepted.
 3. **WebSockets.** Realtime subscriptions use the WebSocket protocol, which has its own handshake and CORS rules. The `wsPath` proxy handles this with cookie forwarding so auth survives the upgrade.
 
@@ -92,20 +92,7 @@ Or disable just the WebSocket proxy by leaving `enabled: true` and setting `wsPa
 
 In production builds the proxy is off by default and all requests go directly to the `client` URL from the browser. This is what most users want: no extra hop, no Nuxt server involvement on every Directus call. For this to work with session auth, cookie domains have to match, either same apex domain or configured correctly. See the [Authentication guide](/guide/authentication) for the cross-domain setup.
 
-### Enabling the proxy in production
-
-Sometimes the direct-from-browser route doesn't work. The most common case is hosting Directus on a different domain than your Nuxt app where you can't (or don't want to) deal with cross-domain cookies. Third-party cookie restrictions in modern browsers make this increasingly fragile, especially in staging environments. Turning the proxy on in production puts the session cookie back on your own origin:
-
-```ts
-export default defineNuxtConfig({
-  directus: {
-    url: process.env.NUXT_PUBLIC_DIRECTUS_URL,
-    proxy: { enabled: true }, // or just `proxy: true`
-  },
-})
-```
-
-With this set, the module registers a Nitro server handler at `/directus/**` in your production build that forwards HTTP requests to Directus, preserving cookies on your own domain.
+Sometimes the direct-from-browser route doesn't work. The most common case is hosting Directus on a different domain than your Nuxt app where you can't (or don't want to) deal with cross-domain cookies. Third-party cookie restrictions in modern browsers make this increasingly fragile, especially in staging environments. Turning the proxy on in production (see [Configuration](#configuration) above) puts the session cookie back on your own origin.
 
 **Trade-offs to know about:**
 
@@ -113,7 +100,7 @@ With this set, the module registers a Nitro server handler at `/directus/**` in 
 - **WebSocket proxy is dev-only.** The realtime proxy uses the Nuxt dev-server's upgrade hook, which doesn't exist in production builds. If you turn the HTTP proxy on in production, realtime connects directly to Directus instead, which means realtime is still subject to the original cross-domain cookie problem if you're using `realtimeAuthMode: 'handshake'` or `'strict'`. For `'public'` realtime (no auth), this is fine.
 - **Serverless caveats.** On platforms like Vercel functions or Netlify functions, the HTTP proxy works (regular request/response). WebSocket proxying wouldn't work even if we could enable it; those runtimes don't hold persistent connections.
 
-If you need realtime with auth in production-with-proxy, the cleanest answer is usually to put Directus on a subdomain of your app (`api.example.com` and `app.example.com`) with `SESSION_COOKIE_DOMAIN=.example.com`, so cookies are shared without proxying.
+If you need realtime with auth in production-with-proxy, the cleanest answer is usually to put Directus on a subdomain of your app (`app.example.com` and `directus.example.com`) with `SESSION_COOKIE_DOMAIN=.example.com`, so cookies are shared without proxying.
 
 ## Client IP & `IP_TRUST_PROXY`
 
@@ -137,17 +124,13 @@ IP_TRUST_PROXY=1
 
 Prefer the hop count (`1`) over a blanket `true`. The SDK proxy already strips the attacker-controllable inbound header and forwards a single clean entry, so trusting one hop gives you the real client IP without re-opening the spoofing hole that `true` is prone to. If you stack another proxy in front of your Nuxt app (e.g. Cloudflare to Nuxt to Directus), increase the count to match.
 
-::: tip Direct mode is unaffected
-This section only applies when the proxy is enabled. With `proxy: false`, browsers talk to Directus directly and it sees the real client IP from the connection itself; `IP_TRUST_PROXY` then only concerns whatever proxy sits in front of Directus.
-:::
-
 ::: warning Resolution is only as trustworthy as your edge
 The proxy resolves the client IP from the request reaching your Nuxt server. If Nuxt is exposed directly to the internet with no trusted edge in front of it, that value can itself be spoofed. Configure your platform / Nitro trust settings so the incoming IP is trustworthy before relying on it downstream.
 :::
 
 ## Migration from `devProxy`
 
-The option was renamed from `devProxy` to `proxy` to reflect that it works in production too. The old name still works as an alias:
+From v6.1 the option was renamed from `devProxy` to `proxy` to reflect that it works in production too. The old name still works as an alias:
 
 ```ts
 // Old (deprecated, still works with a warning)

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -19,7 +19,7 @@ export default defineNuxtConfig({
   directus: {
     // url: import.emeta.env.DIRECTUS_URL
     // adminToken: import.meta.env.DIRECTUS_ADMIN_TOKEN
-    devProxy: {
+    proxy: {
       enabled: true,
       path: '/directus',
     },

--- a/playground/pages/client-utils.vue
+++ b/playground/pages/client-utils.vue
@@ -26,7 +26,7 @@ const visualEditor = useDirectusVisualEditor()
         <code class="text-xs bg-elevated px-1.5 py-0.5 rounded">useDirectusUrl(path?)</code>
       </h2>
       <p class="text-sm text-muted mb-3">
-        Returns the context-aware Directus base URL. On the client it uses the configured URL (or <code class="text-xs bg-elevated px-1 py-0.5 rounded">devProxy</code> path in development).
+        Returns the context-aware Directus base URL. On the client it uses the configured URL (or <code class="text-xs bg-elevated px-1 py-0.5 rounded">proxy</code> path in development).
         On the server it prefers <code class="text-xs bg-elevated px-1 py-0.5 rounded">serverDirectusUrl</code> for internal networking (Docker/K8s), falling back to the client URL.
       </p>
       <UFormField
@@ -50,7 +50,7 @@ const visualEditor = useDirectusVisualEditor()
         <code class="text-xs bg-elevated px-1.5 py-0.5 rounded">useDirectusOriginUrl(path?)</code>
       </h2>
       <p class="text-sm text-muted mb-3">
-        Always returns the real public-facing Directus URL, ignoring both <code class="text-xs bg-elevated px-1 py-0.5 rounded">devProxy</code> and <code class="text-xs bg-elevated px-1 py-0.5 rounded">serverDirectusUrl</code>.
+        Always returns the real public-facing Directus URL, ignoring both <code class="text-xs bg-elevated px-1 py-0.5 rounded">proxy</code> and <code class="text-xs bg-elevated px-1 py-0.5 rounded">serverDirectusUrl</code>.
         Use this for SSO redirects and admin links that must point to the actual Directus origin.
       </p>
       <p class="text-sm font-semibold mb-1">
@@ -58,7 +58,7 @@ const visualEditor = useDirectusVisualEditor()
       </p>
       <code class="block bg-elevated border border-default rounded p-3 text-xs wrap-break-word mb-3">{{ resolvedOriginUrl }}</code>
       <p class="text-xs text-muted italic border-l-2 border-default pl-3">
-        In local development with <code>devProxy</code> enabled, <code>useDirectusUrl()</code> returns the proxy path while <code>useDirectusOriginUrl()</code> returns the real Directus URL.
+        In local development with <code>proxy</code> enabled, <code>useDirectusUrl()</code> returns the proxy path while <code>useDirectusOriginUrl()</code> returns the real Directus URL.
         In production without a proxy they will be the same.
       </p>
     </section>

--- a/src/module.ts
+++ b/src/module.ts
@@ -28,25 +28,36 @@ export interface ModuleOptions {
   url: DirectusUrl
 
   /**
-   * Development proxy configuration
-   * When enabled, creates a proxy at /directus that forwards to your Directus URL
-   * This solves CORS and cookie issues in development
-   * @default { enabled: true, path: '/directus', wsPath: '/directus-ws' } in dev mode
+   * Proxy configuration. When enabled, creates a Nitro server handler at
+   * `path` that forwards HTTP requests to your Directus URL — useful for
+   * cookie-scope (login on the same origin) and CORS workarounds.
+   *
+   * - Defaults to on in dev, off in production.
+   * - Setting `true` (or `{ enabled: true }`) explicitly turns the HTTP
+   *   proxy on in production too.
+   * - The WebSocket proxy (for realtime) is dev-only — it relies on the
+   *   dev-server's upgrade hook which doesn't exist in production builds.
+   *   When the HTTP proxy is on in production, realtime connects directly
+   *   to Directus, so realtime auth still requires same-domain cookies
+   *   (or a public `realtimeAuthMode`).
+   *
+   * @default { enabled: <isDev>, path: '/directus', wsPath: '/directus-ws' (dev only) }
    * @type boolean | { enabled?: boolean, path?: string, wsPath?: string }
    */
   devProxy?: boolean | {
     /**
-     * Enable the development proxy
-     * @default true in dev mode, false in production
+     * Enable the proxy. Defaults to true in dev, false in production.
+     * Explicitly setting `true` enables HTTP proxying in production too.
      */
     enabled?: boolean
     /**
-     * Proxy path (where the proxy will be mounted)
+     * HTTP proxy path (where the Nitro server handler is mounted).
      * @default '/directus'
      */
     path?: string
     /**
-     * WebSocket proxy path (for realtime connections)
+     * WebSocket proxy path (for realtime connections). Dev-mode only —
+     * ignored in production builds.
      * @default '/directus-ws'
      */
     wsPath?: string
@@ -317,94 +328,113 @@ export default defineNuxtModule<ModuleOptions>({
     const wsProxyPath = devProxyConfig.wsPath ?? `${devProxyPath}-ws`
     const wsTarget = joinURL(directusUrl, 'websocket')
 
-    // Set up development proxy if enabled and in dev mode
-    if (devProxyEnabled && nuxtApp.options.dev) {
-      loggerMessage.push(`🌐 Development Proxy Mode Enabled:`)
+    // Proxy resolution:
+    // - HTTP proxy: works in dev and production (Nitro server handler)
+    // - WebSocket proxy: dev only — the upgrade hook below relies on
+    //   nuxtApp.server.upgrade, which exists only in the dev orchestrator.
+    //
+    // Default (devProxyConfig.enabled === undefined): on in dev, off in prod.
+    // Explicit `true`: on in both (HTTP only in prod, with a warning).
+    // Explicit `false`: off in both.
+    const isDev = nuxtApp.options.dev
+
+    if (devProxyEnabled) {
+      const headerLabel = isDev ? '🌐 Development Proxy Mode Enabled:' : '🌐 Proxy Mode Enabled (production):'
+      loggerMessage.push(headerLabel)
       loggerMessage.push(`  - URL${colors.dim(` ${devProxyPath}`)} proxies ${colors.underline(colors.green(`${directusUrl}`))}`)
-      loggerMessage.push(`  - WS URL${colors.dim(` ${wsProxyPath}`)} proxies ${colors.underline(colors.green(`${wsTarget}`))}`, '')
 
-      // Configure WebSocket proxy for realtime support (WebSocket only)
-      nuxtApp.options.nitro = nuxtApp.options.nitro || {}
-      nuxtApp.options.nitro.devProxy = nuxtApp.options.nitro.devProxy || {}
-
-      nuxtApp.options.nitro.devProxy[wsProxyPath] = {
-        target: directusUrl,
-        changeOrigin: true,
-        ws: true,
-      }
-
-      // Set up WebSocket proxy handler using http-proxy
-      // Point to the base Directus URL, we'll rewrite the path in the proxy
-      const httpProxy = await import('http-proxy')
-      const proxy = httpProxy.default.createProxyServer({
-        target: directusUrl,
-        changeOrigin: true,
-        ws: true,
-        secure: false, // Allow self-signed certificates
-      })
-
-      // Add error handling to the proxy
-      proxy.on('error', (err, _req, socket) => {
-        logger.error(`WebSocket proxy error:`, err.message)
-        if (socket && !socket.destroyed) {
-          socket.end()
-        }
-      })
-
-      proxy.on('proxyReqWs', (proxyReq, req, _socket) => {
-        // Rewrite the path from /_directus-ws to /websocket
-        proxyReq.path = '/websocket'
-
-        // Forward cookies for authentication
-        if (req.headers.cookie) {
-          proxyReq.setHeader('cookie', req.headers.cookie)
-        }
-      })
-
-      nuxtApp.hook('ready', () => {
-        const originalUpgrade = nuxtApp.server?.upgrade
-
-        // Replace the nuxt server upgrade handler with our WebSocket proxy
-        if (nuxtApp.server) {
-          // nuxtApp.server.upgrade is not part of Nuxt's public type surface.
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          nuxtApp.server.upgrade = (req: any, socket: any, head: any) => {
-            // Check if this is our WebSocket proxy route
-            if (req.url?.startsWith(wsProxyPath)) {
-              try {
-                proxy.ws(req, socket, head)
-              }
-              catch (error: unknown) {
-                logger.error('WebSocket proxy error:', error instanceof Error ? error.message : String(error))
-                if (!socket.destroyed) {
-                  socket.destroy()
-                }
-              }
-            }
-            else if (originalUpgrade) {
-              return originalUpgrade(req, socket, head)
-            }
-            else if (!socket.destroyed) {
-              socket.destroy()
-            }
-          }
-        }
-      })
-
-      // Add HTTP handler for regular requests
+      // HTTP proxy server handler — works in dev and production builds.
       addServerHandler({
         route: `${devProxyPath}/**`,
         handler: resolver.resolve('./runtime/server/routes/directus'),
       })
 
-      // Store normalized devProxy config for runtime use
+      if (isDev) {
+        loggerMessage.push(`  - WS URL${colors.dim(` ${wsProxyPath}`)} proxies ${colors.underline(colors.green(`${wsTarget}`))}`, '')
+
+        // Configure WebSocket proxy for realtime support (WebSocket only).
+        // Nitro's devProxy is dev-server only; intentionally skipped in prod.
+        nuxtApp.options.nitro = nuxtApp.options.nitro || {}
+        nuxtApp.options.nitro.devProxy = nuxtApp.options.nitro.devProxy || {}
+
+        nuxtApp.options.nitro.devProxy[wsProxyPath] = {
+          target: directusUrl,
+          changeOrigin: true,
+          ws: true,
+        }
+
+        // Set up WebSocket proxy handler using http-proxy
+        // Point to the base Directus URL, we'll rewrite the path in the proxy
+        const httpProxy = await import('http-proxy')
+        const proxy = httpProxy.default.createProxyServer({
+          target: directusUrl,
+          changeOrigin: true,
+          ws: true,
+          secure: false, // Allow self-signed certificates
+        })
+
+        // Add error handling to the proxy
+        proxy.on('error', (err, _req, socket) => {
+          logger.error(`WebSocket proxy error:`, err.message)
+          if (socket && !socket.destroyed) {
+            socket.end()
+          }
+        })
+
+        proxy.on('proxyReqWs', (proxyReq, req, _socket) => {
+          // Rewrite the path from /_directus-ws to /websocket
+          proxyReq.path = '/websocket'
+
+          // Forward cookies for authentication
+          if (req.headers.cookie) {
+            proxyReq.setHeader('cookie', req.headers.cookie)
+          }
+        })
+
+        nuxtApp.hook('ready', () => {
+          const originalUpgrade = nuxtApp.server?.upgrade
+
+          // Replace the nuxt server upgrade handler with our WebSocket proxy
+          if (nuxtApp.server) {
+            // nuxtApp.server.upgrade is not part of Nuxt's public type surface.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            nuxtApp.server.upgrade = (req: any, socket: any, head: any) => {
+              // Check if this is our WebSocket proxy route
+              if (req.url?.startsWith(wsProxyPath)) {
+                try {
+                  proxy.ws(req, socket, head)
+                }
+                catch (error: unknown) {
+                  logger.error('WebSocket proxy error:', error instanceof Error ? error.message : String(error))
+                  if (!socket.destroyed) {
+                    socket.destroy()
+                  }
+                }
+              }
+              else if (originalUpgrade) {
+                return originalUpgrade(req, socket, head)
+              }
+              else if (!socket.destroyed) {
+                socket.destroy()
+              }
+            }
+          }
+        })
+      }
+      else {
+        loggerMessage.push(`  - ${colors.yellow('WebSocket proxy is disabled in production')} — connect realtime directly to ${colors.dim(`${wsTarget}`)}`, '')
+      }
+
+      // Store normalized devProxy config for runtime use.
+      // wsPath is only meaningful when the WS proxy is actually registered (dev),
+      // so leave it undefined in production builds.
       options.devProxy = {
         enabled: true,
         path: devProxyPath,
-        wsPath: wsProxyPath,
+        wsPath: isDev ? wsProxyPath : undefined,
       }
     }
-    else if (!nuxtApp.options.dev && directusUrl) {
+    else if (!isDev && directusUrl) {
       loggerMessage.push(`🌐 Production Mode:`, `  - SDK connects directly to ${colors.dim(`${directusUrl}`)}`, '')
       options.devProxy = false
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,6 +16,28 @@ import { discoverSdkImports } from './sdk-imports'
 export type DirectusUrl = string | { client: string, server: string }
 export type ReadMeFields = Query<DirectusSchema, DirectusUser<DirectusSchema>>['fields']
 
+/**
+ * Shape of the `proxy` (and deprecated `devProxy`) module option.
+ */
+export type ProxyOption = boolean | {
+  /**
+   * Enable the proxy. Defaults to true in dev, false in production.
+   * Explicitly setting `true` enables HTTP proxying in production too.
+   */
+  enabled?: boolean
+  /**
+   * HTTP proxy path (where the Nitro server handler is mounted).
+   * @default '/directus'
+   */
+  path?: string
+  /**
+   * WebSocket proxy path (for realtime connections). Dev-mode only;
+   * ignored in production builds.
+   * @default '/directus-ws'
+   */
+  wsPath?: string
+}
+
 export interface ModuleOptions {
   /**
    * Directus API URL
@@ -29,13 +51,13 @@ export interface ModuleOptions {
 
   /**
    * Proxy configuration. When enabled, creates a Nitro server handler at
-   * `path` that forwards HTTP requests to your Directus URL — useful for
+   * `path` that forwards HTTP requests to your Directus URL. Useful for
    * cookie-scope (login on the same origin) and CORS workarounds.
    *
    * - Defaults to on in dev, off in production.
    * - Setting `true` (or `{ enabled: true }`) explicitly turns the HTTP
    *   proxy on in production too.
-   * - The WebSocket proxy (for realtime) is dev-only — it relies on the
+   * - The WebSocket proxy (for realtime) is dev-only; it relies on the
    *   dev-server's upgrade hook which doesn't exist in production builds.
    *   When the HTTP proxy is on in production, realtime connects directly
    *   to Directus, so realtime auth still requires same-domain cookies
@@ -44,24 +66,14 @@ export interface ModuleOptions {
    * @default { enabled: <isDev>, path: '/directus', wsPath: '/directus-ws' (dev only) }
    * @type boolean | { enabled?: boolean, path?: string, wsPath?: string }
    */
-  devProxy?: boolean | {
-    /**
-     * Enable the proxy. Defaults to true in dev, false in production.
-     * Explicitly setting `true` enables HTTP proxying in production too.
-     */
-    enabled?: boolean
-    /**
-     * HTTP proxy path (where the Nitro server handler is mounted).
-     * @default '/directus'
-     */
-    path?: string
-    /**
-     * WebSocket proxy path (for realtime connections). Dev-mode only —
-     * ignored in production builds.
-     * @default '/directus-ws'
-     */
-    wsPath?: string
-  }
+  proxy?: ProxyOption
+
+  /**
+   * @deprecated Use `proxy` instead. `devProxy` is kept as an alias for
+   * backwards compatibility and will be removed in a future major release.
+   * If both are set, `proxy` wins and `devProxy` is ignored with a warning.
+   */
+  devProxy?: ProxyOption
 
   /**
    * Admin Auth Token used for generating types and server functions
@@ -262,7 +274,8 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     url: import.meta.env.DIRECTUS_URL ?? '',
-    devProxy: undefined, // Will be set based on dev mode in setup
+    proxy: undefined, // Resolved in setup based on dev mode and the deprecated `devProxy` alias.
+    devProxy: undefined,
     adminToken: import.meta.env.DIRECTUS_ADMIN_TOKEN ?? '',
     devtools: true,
     visualEditor: true,
@@ -314,38 +327,57 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
-    // Normalize devProxy options
-    const devProxyConfig = typeof options.devProxy === 'boolean'
-      ? { enabled: options.devProxy }
-      : { ...options.devProxy }
+    // Resolve the proxy option. `proxy` is the canonical name; `devProxy` is
+    // kept as a deprecated alias.
+    //  - If `proxy` is set, use it (and warn if `devProxy` was also set).
+    //  - If only `devProxy` is set, hoist it and emit a deprecation warning.
+    //  - If neither is set, fall through to the default (on in dev, off in prod).
+    if (options.proxy !== undefined && options.devProxy !== undefined) {
+      logger.warn(
+        'Both `proxy` and `devProxy` are set in directus module config. `proxy` wins; `devProxy` is ignored. Remove the deprecated `devProxy` entry.',
+      )
+    }
+    else if (options.proxy === undefined && options.devProxy !== undefined) {
+      logger.warn(
+        '`directus.devProxy` is deprecated and will be removed in a future major release. Rename it to `directus.proxy`.',
+      )
+      options.proxy = options.devProxy
+    }
+    // Clear the deprecated field so it doesn't leak into runtimeConfig.
+    options.devProxy = undefined
+
+    // Normalize the resolved proxy option into a config object.
+    const proxyConfig = typeof options.proxy === 'boolean'
+      ? { enabled: options.proxy }
+      : { ...options.proxy }
 
     // Server URL used for proxy target, type gen, devtools (all server-side operations)
     const directusUrl = serverUrl || clientUrl
 
-    const devProxyEnabled = devProxyConfig.enabled ?? nuxtApp.options.dev
-    const devProxyPath = devProxyConfig.path ?? '/directus'
+    const proxyEnabled = proxyConfig.enabled ?? nuxtApp.options.dev
+    const proxyPath = proxyConfig.path ?? '/directus'
     // Use a separate route for WebSocket proxy to avoid conflicts with the HTTP handler
-    const wsProxyPath = devProxyConfig.wsPath ?? `${devProxyPath}-ws`
+    const wsProxyPath = proxyConfig.wsPath ?? `${proxyPath}-ws`
     const wsTarget = joinURL(directusUrl, 'websocket')
 
     // Proxy resolution:
     // - HTTP proxy: works in dev and production (Nitro server handler)
-    // - WebSocket proxy: dev only — the upgrade hook below relies on
+    // - WebSocket proxy: dev only; the upgrade hook below relies on
     //   nuxtApp.server.upgrade, which exists only in the dev orchestrator.
     //
-    // Default (devProxyConfig.enabled === undefined): on in dev, off in prod.
+    // Default (proxyConfig.enabled === undefined): on in dev, off in prod.
     // Explicit `true`: on in both (HTTP only in prod, with a warning).
     // Explicit `false`: off in both.
     const isDev = nuxtApp.options.dev
 
-    if (devProxyEnabled) {
+    if (proxyEnabled) {
       const headerLabel = isDev ? '🌐 Development Proxy Mode Enabled:' : '🌐 Proxy Mode Enabled (production):'
       loggerMessage.push(headerLabel)
-      loggerMessage.push(`  - URL${colors.dim(` ${devProxyPath}`)} proxies ${colors.underline(colors.green(`${directusUrl}`))}`)
+      loggerMessage.push(`  - URL${colors.dim(` ${proxyPath}`)} proxies ${colors.underline(colors.green(`${directusUrl}`))}`)
 
-      // HTTP proxy server handler — works in dev and production builds.
+      // HTTP proxy server handler; works in dev and production builds.
       addServerHandler({
-        route: `${devProxyPath}/**`,
+        route: `${proxyPath}/**`,
         handler: resolver.resolve('./runtime/server/routes/directus'),
       })
 
@@ -422,21 +454,21 @@ export default defineNuxtModule<ModuleOptions>({
         })
       }
       else {
-        loggerMessage.push(`  - ${colors.yellow('WebSocket proxy is disabled in production')} — connect realtime directly to ${colors.dim(`${wsTarget}`)}`, '')
+        loggerMessage.push(`  - ${colors.yellow('WebSocket proxy is disabled in production')}; connect realtime directly to ${colors.dim(`${wsTarget}`)}`, '')
       }
 
-      // Store normalized devProxy config for runtime use.
+      // Store normalized proxy config for runtime use.
       // wsPath is only meaningful when the WS proxy is actually registered (dev),
       // so leave it undefined in production builds.
-      options.devProxy = {
+      options.proxy = {
         enabled: true,
-        path: devProxyPath,
+        path: proxyPath,
         wsPath: isDev ? wsProxyPath : undefined,
       }
     }
     else if (!isDev && directusUrl) {
       loggerMessage.push(`🌐 Production Mode:`, `  - SDK connects directly to ${colors.dim(`${directusUrl}`)}`, '')
-      options.devProxy = false
+      options.proxy = false
     }
 
     // directusUrl/serverDirectusUrl are injected onto options so Nuxt's type
@@ -458,6 +490,11 @@ export default defineNuxtModule<ModuleOptions>({
     delete (nuxtApp.options.runtimeConfig.public[configKey] as any).adminToken
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (nuxtApp.options.runtimeConfig.public[configKey] as any).serverDirectusUrl
+    // Strip the deprecated alias so runtime reads from `proxy` only.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (nuxtApp.options.runtimeConfig.public[configKey] as any).devProxy
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (nuxtApp.options.runtimeConfig[configKey] as any).devProxy
 
     // Register @nuxt/image with Directus provider
     const imageConfig = typeof options.image === 'boolean' ? { enabled: options.image } : options.image
@@ -468,8 +505,8 @@ export default defineNuxtModule<ModuleOptions>({
     if (hasNuxtImage) {
       const { setDefaultProvider, modifiers } = imageConfig || {}
 
-      const imageBaseUrl = devProxyEnabled
-        ? `${devProxyPath}/assets`
+      const imageBaseUrl = proxyEnabled
+        ? `${proxyPath}/assets`
         : useUrl(clientUrl, 'assets')
 
       await registerModule('@nuxt/image', 'image', {

--- a/src/module.ts
+++ b/src/module.ts
@@ -69,9 +69,7 @@ export interface ModuleOptions {
   proxy?: ProxyOption
 
   /**
-   * @deprecated Use `proxy` instead. `devProxy` is kept as an alias for
-   * backwards compatibility and will be removed in a future major release.
-   * If both are set, `proxy` wins and `devProxy` is ignored with a warning.
+   * @deprecated Use `proxy` instead. `devProxy` will be removed in the next major release.
    */
   devProxy?: ProxyOption
 
@@ -274,7 +272,7 @@ export default defineNuxtModule<ModuleOptions>({
   },
   defaults: {
     url: import.meta.env.DIRECTUS_URL ?? '',
-    proxy: undefined, // Resolved in setup based on dev mode and the deprecated `devProxy` alias.
+    proxy: undefined, // Resolved in setup based on dev mode.
     devProxy: undefined,
     adminToken: import.meta.env.DIRECTUS_ADMIN_TOKEN ?? '',
     devtools: true,

--- a/src/runtime/composables/directus.ts
+++ b/src/runtime/composables/directus.ts
@@ -23,19 +23,19 @@ function resolveServerUrl(): string {
   return config.directus?.serverDirectusUrl || resolveClientUrl()
 }
 
-// The module writes devProxy as a full object; the generated runtime-config.d.ts
+// The module writes proxy as a full object; the generated runtime-config.d.ts
 // collapses it to boolean. Cast to the actual shape so property access is safe.
-type DevProxyConfig = boolean | { enabled?: boolean, path?: string, wsPath?: string }
+type ProxyConfig = boolean | { enabled?: boolean, path?: string, wsPath?: string }
 
 export function useDirectusUrl(path = ''): string {
   const config = useRuntimeConfig()
 
-  const devProxy = config.public.directus.devProxy as DevProxyConfig
-  const devProxyEnabled = typeof devProxy === 'object' ? devProxy.enabled === true : devProxy === true
+  const proxy = config.public.directus.proxy as ProxyConfig
+  const proxyEnabled = typeof proxy === 'object' ? proxy.enabled === true : proxy === true
 
-  // When devProxy is enabled, use current origin + proxy path
-  if (devProxyEnabled) {
-    const proxyPath = typeof devProxy === 'object' && devProxy.path ? devProxy.path : '/directus'
+  // When the proxy is enabled, use current origin + proxy path
+  if (proxyEnabled) {
+    const proxyPath = typeof proxy === 'object' && proxy.path ? proxy.path : '/directus'
 
     if (import.meta.client) {
       return useUrl(`${window.location.origin}${proxyPath}`, path)
@@ -50,7 +50,7 @@ export function useDirectusUrl(path = ''): string {
     }
   }
 
-  // On server without devProxy, prefer the server URL (for Docker/K8s internal networking)
+  // On server without proxy, prefer the server URL (for Docker/K8s internal networking)
   if (import.meta.server) {
     return useUrl(resolveServerUrl(), path)
   }
@@ -98,17 +98,17 @@ function createDirectusClient() {
   //
   // - Dev with WS proxy: use the proxy path on the current origin.
   // - HTTP proxy on but no WS proxy (production): point realtime directly at
-  //   the real Directus URL — the HTTP proxy can't carry WebSocket upgrades.
+  //   the real Directus URL; the HTTP proxy can't carry WebSocket upgrades.
   // - No proxy: omit, let the SDK default (baseUrl + /websocket).
-  const devProxy = config.public.directus.devProxy as DevProxyConfig
-  const devProxyEnabled = typeof devProxy === 'object' ? devProxy.enabled === true : devProxy === true
-  const devProxyWsPath = typeof devProxy === 'object' ? devProxy.wsPath : undefined
+  const proxy = config.public.directus.proxy as ProxyConfig
+  const proxyEnabled = typeof proxy === 'object' ? proxy.enabled === true : proxy === true
+  const proxyWsPath = typeof proxy === 'object' ? proxy.wsPath : undefined
 
   let realtimeUrl: string | undefined
-  if (devProxyWsPath && import.meta.client) {
-    realtimeUrl = `${window.location.origin}${devProxyWsPath}`
+  if (proxyWsPath && import.meta.client) {
+    realtimeUrl = `${window.location.origin}${proxyWsPath}`
   }
-  else if (devProxyEnabled && import.meta.client) {
+  else if (proxyEnabled && import.meta.client) {
     // Production proxy mode: realtime bypasses the proxy and connects directly.
     const directUrl = resolveClientUrl()
     realtimeUrl = directUrl ? `${directUrl.replace(/^http/, 'ws').replace(/\/$/, '')}/websocket` : undefined

--- a/src/runtime/composables/directus.ts
+++ b/src/runtime/composables/directus.ts
@@ -94,14 +94,26 @@ function createDirectusClient() {
 
   const baseUrl = useDirectusUrl()
 
-  // Get WebSocket URL if devProxy is enabled
+  // Resolve the realtime WebSocket URL.
+  //
+  // - Dev with WS proxy: use the proxy path on the current origin.
+  // - HTTP proxy on but no WS proxy (production): point realtime directly at
+  //   the real Directus URL — the HTTP proxy can't carry WebSocket upgrades.
+  // - No proxy: omit, let the SDK default (baseUrl + /websocket).
   const devProxy = config.public.directus.devProxy as DevProxyConfig
-  const devProxyWsUrl = devProxy && typeof devProxy === 'object' && devProxy.wsPath && import.meta.client
-    ? `${window.location.origin}${devProxy.wsPath}`
-    : undefined
+  const devProxyEnabled = typeof devProxy === 'object' ? devProxy.enabled === true : devProxy === true
+  const devProxyWsPath = typeof devProxy === 'object' ? devProxy.wsPath : undefined
 
-  // In dev mode with proxy, use the separate WebSocket proxy path
-  // Otherwise, let the SDK use the default (baseUrl + /websocket)
+  let realtimeUrl: string | undefined
+  if (devProxyWsPath && import.meta.client) {
+    realtimeUrl = `${window.location.origin}${devProxyWsPath}`
+  }
+  else if (devProxyEnabled && import.meta.client) {
+    // Production proxy mode: realtime bypasses the proxy and connects directly.
+    const directUrl = resolveClientUrl()
+    realtimeUrl = directUrl ? `${directUrl.replace(/^http/, 'ws').replace(/\/$/, '')}/websocket` : undefined
+  }
+
   const directus = createDirectus<DirectusSchema>(baseUrl, {
     globals: {
       fetch: customFetch,
@@ -118,8 +130,7 @@ function createDirectusClient() {
     }))
     .with(realtime({
       authMode: authConfig.realtimeAuthMode as WebSocketAuthModes || 'public',
-      // Only set custom URL if we have a proxy path (dev mode with proxy enabled)
-      ...(devProxyWsUrl ? { url: devProxyWsUrl } : {}),
+      ...(realtimeUrl ? { url: realtimeUrl } : {}),
     }))
 
   return directus

--- a/src/runtime/server/routes/directus-cookie.ts
+++ b/src/runtime/server/routes/directus-cookie.ts
@@ -1,0 +1,56 @@
+// Cookie rewriting for the proxy server handler. Pure function — kept in its
+// own module so it can be unit-tested without spinning up h3.
+
+export interface RewriteOptions {
+  /**
+   * Whether the incoming request reaching the proxy is HTTPS.
+   * - On HTTPS (production, staging): preserve `Secure` and `SameSite=None` as
+   *   Directus set them — they're valid and load-bearing for cross-context flows.
+   * - On HTTP (localhost dev): strip `Secure` (browser rejects on http://) and
+   *   downgrade `SameSite=None` to `Lax` (browser rejects `None` without `Secure`).
+   */
+  isHttps: boolean
+}
+
+/**
+ * Rewrite a single `Set-Cookie` header value from a proxied Directus response
+ * so it works on the proxy origin (e.g. `your-app.vercel.app` or `localhost`).
+ *
+ * Always:
+ *  - Strips the `Domain` attribute. The cookie binds to the response origin
+ *    instead, which is what we want — it lets the browser store the cookie on
+ *    your Nuxt app's host rather than Directus's.
+ *
+ * On HTTP only:
+ *  - Strips `Secure` (browsers reject `Secure` cookies over plain HTTP).
+ *  - Downgrades `SameSite=None` to `SameSite=Lax` (browsers reject `None`
+ *    without `Secure`).
+ *  - Adds `SameSite=Lax` if the cookie has no `SameSite` directive at all
+ *    (Safari/Chrome treat missing `SameSite` as `Lax` anyway; making it
+ *    explicit avoids future warnings).
+ */
+export function rewriteProxiedSetCookie(cookie: string, options: RewriteOptions): string {
+  let result = cookie.replace(/;\s*Domain=[^;]+/gi, '')
+
+  if (options.isHttps) {
+    // HTTPS path: leave Secure and SameSite as Directus set them. Just the
+    // domain strip is needed so the browser binds the cookie to our origin.
+    return result
+  }
+
+  // HTTP path (localhost dev). The browser would reject `Secure` and
+  // `SameSite=None` over plain HTTP, so downgrade.
+  if (/SameSite=None/i.test(result)) {
+    result = result
+      .replace(/;\s*SameSite=None/gi, '; SameSite=Lax')
+      .replace(/;\s*Secure\s*(?=;|$)/gi, '')
+  }
+  else {
+    result = result.replace(/;\s*Secure\s*(?=;|$)/gi, '')
+    if (!/SameSite=/i.test(result)) {
+      result += '; SameSite=Lax'
+    }
+  }
+
+  return result
+}

--- a/src/runtime/server/routes/directus.ts
+++ b/src/runtime/server/routes/directus.ts
@@ -1,5 +1,5 @@
 import { useRuntimeConfig } from '#imports'
-import { defineEventHandler, getRequestURL, proxyRequest, setResponseHeaders } from 'h3'
+import { defineEventHandler, getRequestIP, getRequestURL, proxyRequest, setResponseHeaders } from 'h3'
 import { joinURL } from 'ufo'
 import { rewriteProxiedSetCookie } from './directus-cookie'
 
@@ -16,9 +16,28 @@ export default defineEventHandler(async (event) => {
   // on HTTPS (production, staging) and downgrade only on HTTP (localhost dev).
   const isHttps = url.protocol === 'https:'
 
+  // Normalise the forwarded client IP.
+  //
+  // h3's proxy forwards the *inbound* `X-Forwarded-For` verbatim. That header is
+  // attacker-controllable, so a downstream Directus configured to trust it
+  // (`IP_TRUST_PROXY`) could be tricked into believing a spoofed client IP and
+  // bypass IP allow-lists / per-IP rate limits. We instead resolve the client IP
+  // at *this* hop and forward it as a single, clean entry, so Directus can safely
+  // trust exactly one proxy hop (`IP_TRUST_PROXY=1`).
+  //
+  // Backwards compatible: a Directus on the pre-12 default (`IP_TRUST_PROXY=true`,
+  // which reads the left-most XFF entry) resolves this single value to the same
+  // client IP it would have before — so existing/un-upgraded deployments keep
+  // working unchanged. The resolution is only as trustworthy as this app's own
+  // edge: if Nuxt sits directly on the internet, set your platform/Nitro trust
+  // config so `getRequestIP` can't be spoofed.
+  const clientIp = getRequestIP(event, { xForwardedFor: true })
+  const forwardedHeaders = clientIp ? { 'x-forwarded-for': clientIp } : {}
+
   // Proxy the request to Directus
   // Note: WebSocket connections are not supported through this proxy, custom proxy written in module.ts
   await proxyRequest(event, joinURL(directusUrl, path), {
+    headers: forwardedHeaders,
     onResponse(proxyEvent, response) {
       const setCookieHeaders = response.headers.getSetCookie?.() || []
 

--- a/src/runtime/server/routes/directus.ts
+++ b/src/runtime/server/routes/directus.ts
@@ -1,6 +1,7 @@
 import { useRuntimeConfig } from '#imports'
 import { defineEventHandler, getRequestURL, proxyRequest, setResponseHeaders } from 'h3'
 import { joinURL } from 'ufo'
+import { rewriteProxiedSetCookie } from './directus-cookie'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
@@ -11,45 +12,21 @@ export default defineEventHandler(async (event) => {
   const url = getRequestURL(event)
   const path = url.pathname.replace(/^\/directus/, '') + url.search
 
+  // Whether the request reaching us is HTTPS. We preserve Secure/SameSite=None
+  // on HTTPS (production, staging) and downgrade only on HTTP (localhost dev).
+  const isHttps = url.protocol === 'https:'
+
   // Proxy the request to Directus
   // Note: WebSocket connections are not supported through this proxy, custom proxy written in module.ts
   await proxyRequest(event, joinURL(directusUrl, path), {
-    // Intercept response to rewrite cookies for local development
     onResponse(proxyEvent, response) {
-      // Get Set-Cookie headers
       const setCookieHeaders = response.headers.getSetCookie?.() || []
 
       if (setCookieHeaders.length > 0) {
-        // Rewrite each cookie to work with local development
-        const rewrittenCookies = setCookieHeaders.map((cookie) => {
-          // Remove Domain attribute to allow cookies to work on localhost
-          // This allows cookies to work in local dev regardless of Directus domain
-          let rewrittenCookie = cookie.replace(/;\s*Domain=[^;]+/gi, '')
+        const rewrittenCookies = setCookieHeaders.map(cookie =>
+          rewriteProxiedSetCookie(cookie, { isHttps }),
+        )
 
-          // Handle SameSite for Safari compatibility
-          const hasSameSiteNone = rewrittenCookie.match(/SameSite=None/i)
-
-          if (hasSameSiteNone) {
-            // Safari requires Secure flag with SameSite=None
-            // But Secure doesn't work on localhost HTTP, so change to SameSite=Lax
-            rewrittenCookie = rewrittenCookie
-              .replace(/;\s*SameSite=None/gi, '; SameSite=Lax')
-              .replace(/;\s*Secure\s*(?=;|$)/gi, '') // Remove Secure flag for localhost HTTP
-          }
-          else {
-            // Remove Secure flag for localhost HTTP
-            rewrittenCookie = rewrittenCookie.replace(/;\s*Secure\s*(?=;|$)/gi, '')
-
-            // Ensure SameSite is set for Safari compatibility
-            if (!rewrittenCookie.match(/SameSite=/i)) {
-              rewrittenCookie += '; SameSite=Lax'
-            }
-          }
-
-          return rewrittenCookie
-        })
-
-        // Set rewritten cookies on the proxy event (our Nuxt response)
         setResponseHeaders(proxyEvent, {
           'set-cookie': rewrittenCookies,
         })

--- a/test/fixtures/nuxt/runtime-config.data.ts
+++ b/test/fixtures/nuxt/runtime-config.data.ts
@@ -2,7 +2,7 @@ export interface RuntimeConfigOverrides {
   url?: string | { client: string, server: string }
   directusUrl?: string
   serverDirectusUrl?: string
-  devProxy?: boolean | { enabled: boolean, path?: string, wsPath?: string }
+  proxy?: boolean | { enabled: boolean, path?: string, wsPath?: string }
 }
 
 export function makeRuntimeConfig(overrides: RuntimeConfigOverrides) {
@@ -11,7 +11,7 @@ export function makeRuntimeConfig(overrides: RuntimeConfigOverrides) {
       directus: {
         url: overrides.url ?? 'https://public.example.com',
         directusUrl: overrides.directusUrl,
-        devProxy: overrides.devProxy ?? false,
+        proxy: overrides.proxy ?? false,
       },
     },
     directus: {

--- a/test/proxy-cookie.test.ts
+++ b/test/proxy-cookie.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { rewriteProxiedSetCookie } from '../src/runtime/server/routes/directus-cookie'
+
+describe('rewriteProxiedSetCookie() — HTTPS (production/staging)', () => {
+  it('preserves Secure and SameSite=None on HTTPS so cross-context flows keep working', () => {
+    const input = 'directus_session_token=abc; Path=/; Domain=directus.example.com; Secure; HttpOnly; SameSite=None'
+    const result = rewriteProxiedSetCookie(input, { isHttps: true })
+
+    expect(result).toContain('Secure')
+    expect(result).toContain('SameSite=None')
+    expect(result).toContain('HttpOnly')
+    expect(result).not.toContain('Domain=')
+  })
+
+  it('strips Domain on HTTPS so the cookie binds to the proxy origin', () => {
+    const input = 'directus_session_token=abc; Path=/; Domain=directus.example.com; Secure; HttpOnly; SameSite=Lax'
+    const result = rewriteProxiedSetCookie(input, { isHttps: true })
+
+    expect(result).not.toContain('Domain=')
+  })
+
+  it('does not add a SameSite directive when one already exists', () => {
+    const input = 'directus_session_token=abc; Path=/; SameSite=Strict'
+    const result = rewriteProxiedSetCookie(input, { isHttps: true })
+
+    expect(result).toBe(input)
+  })
+})
+
+describe('rewriteProxiedSetCookie() — HTTP (localhost dev)', () => {
+  it('strips Secure so the browser will accept the cookie over plain HTTP', () => {
+    const input = 'directus_session_token=abc; Path=/; Domain=directus.example.com; Secure; HttpOnly; SameSite=Lax'
+    const result = rewriteProxiedSetCookie(input, { isHttps: false })
+
+    expect(result).not.toMatch(/Secure/)
+  })
+
+  it('downgrades SameSite=None to SameSite=Lax and strips Secure', () => {
+    const input = 'directus_session_token=abc; Path=/; Domain=directus.example.com; Secure; SameSite=None'
+    const result = rewriteProxiedSetCookie(input, { isHttps: false })
+
+    expect(result).toContain('SameSite=Lax')
+    expect(result).not.toContain('SameSite=None')
+    expect(result).not.toMatch(/Secure/)
+  })
+
+  it('adds SameSite=Lax when the original cookie has no SameSite directive', () => {
+    const input = 'directus_session_token=abc; Path=/; HttpOnly'
+    const result = rewriteProxiedSetCookie(input, { isHttps: false })
+
+    expect(result).toContain('SameSite=Lax')
+  })
+
+  it('strips Domain on HTTP too', () => {
+    const input = 'directus_session_token=abc; Path=/; Domain=directus.example.com; SameSite=Lax'
+    const result = rewriteProxiedSetCookie(input, { isHttps: false })
+
+    expect(result).not.toContain('Domain=')
+  })
+
+  it('does not duplicate SameSite when one is already present', () => {
+    const input = 'directus_session_token=abc; Path=/; SameSite=Lax'
+    const result = rewriteProxiedSetCookie(input, { isHttps: false })
+
+    const sameSiteMatches = result.match(/SameSite=/gi) || []
+    expect(sameSiteMatches).toHaveLength(1)
+  })
+})

--- a/test/url-helpers.client.test.ts
+++ b/test/url-helpers.client.test.ts
@@ -56,7 +56,7 @@ describe('useDirectusUrl (client-side)', () => {
   it('returns client URL when no proxy', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -67,7 +67,7 @@ describe('useDirectusUrl (client-side)', () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://cms_directus:8055',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -77,10 +77,10 @@ describe('useDirectusUrl (client-side)', () => {
     expect(result).not.toContain('cms_directus')
   })
 
-  it('with devProxy enabled, uses window.location.origin + proxy path', async () => {
+  it('with proxy enabled, uses window.location.origin + proxy path', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: { enabled: true, path: '/directus' },
+      proxy: { enabled: true, path: '/directus' },
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -92,10 +92,10 @@ describe('useDirectusUrl (client-side)', () => {
     expect(result).not.toContain('public.example.com')
   })
 
-  it('with devProxy enabled, uses default /directus path when not specified', async () => {
+  it('with proxy enabled, uses default /directus path when not specified', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: { enabled: true },
+      proxy: { enabled: true },
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -105,10 +105,10 @@ describe('useDirectusUrl (client-side)', () => {
     expect(result).toContain('/directus')
   })
 
-  it('with devProxy as boolean true, uses proxy path', async () => {
+  it('with proxy as boolean true, uses proxy path', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: true,
+      proxy: true,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -119,11 +119,11 @@ describe('useDirectusUrl (client-side)', () => {
   })
 })
 
-describe('devProxy disabled (client-side)', () => {
-  it('devProxy: false — uses client URL directly', async () => {
+describe('proxy disabled (client-side)', () => {
+  it('proxy: false — uses client URL directly', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -134,10 +134,10 @@ describe('devProxy disabled (client-side)', () => {
     expect(result).not.toContain('/directus/')
   })
 
-  it('devProxy: { enabled: false } — uses client URL directly', async () => {
+  it('proxy: { enabled: false } — uses client URL directly', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: { enabled: false, path: '/directus' },
+      proxy: { enabled: false, path: '/directus' },
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -147,13 +147,13 @@ describe('devProxy disabled (client-side)', () => {
     expect(result).not.toContain('/directus/')
   })
 
-  it('devProxy: undefined — does NOT activate proxy, uses client URL', async () => {
+  it('proxy: undefined — does NOT activate proxy, uses client URL', async () => {
     mockRuntimeConfig.mockReturnValue({
       public: {
         directus: {
           url: 'https://public.example.com',
           directusUrl: 'https://public.example.com',
-          // devProxy intentionally omitted (undefined)
+          // proxy intentionally omitted (undefined)
         },
       },
       directus: {},
@@ -167,11 +167,11 @@ describe('devProxy disabled (client-side)', () => {
     expect(result).not.toContain('/directus')
   })
 
-  it('devProxy disabled with no serverDirectusUrl — uses client URL', async () => {
+  it('proxy disabled with no serverDirectusUrl — uses client URL', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: undefined,
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -179,12 +179,12 @@ describe('devProxy disabled (client-side)', () => {
   })
 })
 
-describe('devProxy with { client, server } URL (client-side)', () => {
-  it('devProxy enabled — uses proxy path from window.location.origin', async () => {
+describe('proxy with { client, server } URL (client-side)', () => {
+  it('proxy enabled — uses proxy path from window.location.origin', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: true, path: '/api' },
+      proxy: { enabled: true, path: '/api' },
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -196,11 +196,11 @@ describe('devProxy with { client, server } URL (client-side)', () => {
     expect(result).not.toContain('public.example.com')
   })
 
-  it('devProxy enabled — appends path correctly', async () => {
+  it('proxy enabled — appends path correctly', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: true, path: '/directus' },
+      proxy: { enabled: true, path: '/directus' },
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -211,11 +211,11 @@ describe('devProxy with { client, server } URL (client-side)', () => {
     expect(result).toContain('/items/posts')
   })
 
-  it('devProxy disabled — uses client URL, never serverDirectusUrl', async () => {
+  it('proxy disabled — uses client URL, never serverDirectusUrl', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -226,11 +226,11 @@ describe('devProxy with { client, server } URL (client-side)', () => {
     expect(result).not.toContain(`${MOCK_ORIGIN}/directus`)
   })
 
-  it('useDirectusOriginUrl always returns client URL regardless of devProxy', async () => {
+  it('useDirectusOriginUrl always returns client URL regardless of proxy', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: true, path: '/directus' },
+      proxy: { enabled: true, path: '/directus' },
     })
 
     const { useDirectusOriginUrl } = await import('../src/runtime/composables/directus')
@@ -247,7 +247,7 @@ describe('simple string URL (client-side)', () => {
     setConfig({
       url: 'https://cms.example.com',
       directusUrl: 'https://cms.example.com',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -258,7 +258,7 @@ describe('simple string URL (client-side)', () => {
     setConfig({
       url: 'https://cms.example.com',
       directusUrl: 'https://cms.example.com',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -271,7 +271,7 @@ describe('simple string URL (client-side)', () => {
     setConfig({
       url: 'https://cms.example.com',
       directusUrl: 'https://cms.example.com',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl, useDirectusOriginUrl } = await import('../src/runtime/composables/directus')
@@ -296,7 +296,7 @@ describe('url as object { client, server } (client-side)', () => {
       url: { client: 'https://public.example.com', server: 'http://internal:8055' },
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')

--- a/test/url-helpers.server.test.ts
+++ b/test/url-helpers.server.test.ts
@@ -57,10 +57,10 @@ describe('useDirectusOriginUrl (server-side)', () => {
     expect(result).toContain('/auth/login/google')
   })
 
-  it('ignores devProxy — always returns the real client URL', async () => {
+  it('ignores proxy — always returns the real client URL', async () => {
     setConfig({
       directusUrl: 'https://directus.example.com',
-      devProxy: { enabled: true, path: '/directus', wsPath: '/directus-ws' },
+      proxy: { enabled: true, path: '/directus', wsPath: '/directus-ws' },
     })
 
     const { useDirectusOriginUrl } = await import('../src/runtime/composables/directus')
@@ -121,11 +121,11 @@ describe('useDirectusUrl (server-side)', () => {
     expect(result).toContain('/items/posts')
   })
 
-  it('with devProxy enabled, uses proxy path from request headers', async () => {
+  it('with proxy enabled, uses proxy path from request headers', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://cms_directus:8055',
-      devProxy: { enabled: true, path: '/directus' },
+      proxy: { enabled: true, path: '/directus' },
     })
     mockRequestHeaders.mockReturnValue({ host: 'localhost:3000' })
 
@@ -137,10 +137,10 @@ describe('useDirectusUrl (server-side)', () => {
     expect(result).toContain('/items/posts')
   })
 
-  it('with devProxy as boolean true, uses proxy path from request headers', async () => {
+  it('with proxy as boolean true, uses proxy path from request headers', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
-      devProxy: true,
+      proxy: true,
     })
     mockRequestHeaders.mockReturnValue({ host: 'localhost:3000' })
 
@@ -153,12 +153,12 @@ describe('useDirectusUrl (server-side)', () => {
   })
 })
 
-describe('devProxy disabled (server-side)', () => {
-  it('devProxy: false — uses serverDirectusUrl directly', async () => {
+describe('proxy disabled (server-side)', () => {
+  it('proxy: false — uses serverDirectusUrl directly', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -169,11 +169,11 @@ describe('devProxy disabled (server-side)', () => {
     expect(result).not.toContain('/directus')
   })
 
-  it('devProxy: { enabled: false } — uses serverDirectusUrl directly', async () => {
+  it('proxy: { enabled: false } — uses serverDirectusUrl directly', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: false, path: '/directus' },
+      proxy: { enabled: false, path: '/directus' },
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -183,13 +183,13 @@ describe('devProxy disabled (server-side)', () => {
     expect(result).not.toContain('/directus/')
   })
 
-  it('devProxy: undefined — does NOT activate proxy, uses serverDirectusUrl', async () => {
+  it('proxy: undefined — does NOT activate proxy, uses serverDirectusUrl', async () => {
     mockRuntimeConfig.mockReturnValue({
       public: {
         directus: {
           url: 'https://public.example.com',
           directusUrl: 'https://public.example.com',
-          // devProxy intentionally omitted (undefined)
+          // proxy intentionally omitted (undefined)
         },
       },
       directus: {
@@ -205,11 +205,11 @@ describe('devProxy disabled (server-side)', () => {
     expect(result).not.toContain('/directus')
   })
 
-  it('devProxy disabled with no serverDirectusUrl — uses client URL', async () => {
+  it('proxy disabled with no serverDirectusUrl — uses client URL', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: undefined,
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -217,12 +217,12 @@ describe('devProxy disabled (server-side)', () => {
   })
 })
 
-describe('devProxy with { client, server } URL (server-side)', () => {
-  it('devProxy enabled — uses proxy path, not serverDirectusUrl', async () => {
+describe('proxy with { client, server } URL (server-side)', () => {
+  it('proxy enabled — uses proxy path, not serverDirectusUrl', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: true, path: '/api' },
+      proxy: { enabled: true, path: '/api' },
     })
     mockRequestHeaders.mockReturnValue({ host: 'localhost:3000' })
 
@@ -235,11 +235,11 @@ describe('devProxy with { client, server } URL (server-side)', () => {
     expect(result).not.toContain('public.example.com')
   })
 
-  it('devProxy disabled — uses serverDirectusUrl, not client URL', async () => {
+  it('proxy disabled — uses serverDirectusUrl, not client URL', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: false,
+      proxy: false,
     })
 
     const { useDirectusUrl } = await import('../src/runtime/composables/directus')
@@ -249,11 +249,11 @@ describe('devProxy with { client, server } URL (server-side)', () => {
     expect(result).not.toContain('public.example.com')
   })
 
-  it('devProxy enabled but no request headers — falls through to serverDirectusUrl', async () => {
+  it('proxy enabled but no request headers — falls through to serverDirectusUrl', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: true, path: '/directus' },
+      proxy: { enabled: true, path: '/directus' },
     })
     mockRequestHeaders.mockReturnValue({}) // no host header
 
@@ -264,11 +264,11 @@ describe('devProxy with { client, server } URL (server-side)', () => {
     expect(result).toContain('internal:8055')
   })
 
-  it('useDirectusOriginUrl always returns client URL regardless of devProxy', async () => {
+  it('useDirectusOriginUrl always returns client URL regardless of proxy', async () => {
     setConfig({
       directusUrl: 'https://public.example.com',
       serverDirectusUrl: 'http://internal:8055',
-      devProxy: { enabled: true, path: '/directus' },
+      proxy: { enabled: true, path: '/directus' },
     })
 
     const { useDirectusOriginUrl } = await import('../src/runtime/composables/directus')


### PR DESCRIPTION
### Summary

Two related fixes for the proxy:

1. **\`devProxy: true\` now works in production builds**, not just \`nuxt dev\`. Previously, the module hard-stripped \`devProxy\` whenever \`nuxtApp.options.dev\` was false, even with explicit user opt-in. The HTTP proxy is genuinely useful in production for cookie-scope problems (e.g. login on Vercel where your app and Directus are on different domains).
2. **Cookie rewriting is now protocol-aware.** The old logic was written for localhost HTTP — it stripped \`Secure\` and downgraded \`SameSite=None\` to \`Lax\` unconditionally. On HTTPS (Vercel, staging, production), that's a security regression and could break cross-context flows. Now we only downgrade on HTTP and preserve cookies as Directus set them on HTTPS.

### What's in scope

- HTTP proxy: works in dev and production builds
- WebSocket proxy: **dev-only** (the current implementation hooks \`nuxtApp.server.upgrade\` which doesn't exist in production)
- In production with HTTP proxy on, realtime points directly at Directus (the SDK realtime URL is set to the real Directus URL, bypassing the proxy)

Default behaviour is unchanged: proxy on in dev, off in production. Opt-in only.

### Why now

User flagged that a Vercel staging deployment with cross-domain cookies needed the proxy on, but the module silently dropped it. Login flow blocked.

### Tested

- \`pnpm lint\`, \`pnpm test\` clean (357 passing, 0 type errors)
- 7 new tests for the cookie rewriter covering both HTTPS and HTTP paths
- Verified manually: \`useDirectusUrl()\` already handles proxy-mode for SSR/client, so no runtime-side changes needed beyond the realtime URL override
- Docs updated with the production-proxy use case, WS limitation, and serverless trade-offs

### Migration

None for default behaviour. If you explicitly set \`devProxy: { enabled: true }\` you'll now get an HTTP proxy in production too — that's the fix.

### Linked issue

None directly; follow-up to the conversation around staging/cookie scope in chat.

### Checklist

- [x] Tests added (\`test/proxy-cookie.test.ts\`)
- [x] Docs updated (\`docs/guide/dev-proxy.md\`)
- [x] Targeting \`next\`
- [x] \`pnpm lint\` and \`pnpm test\` pass locally