### PR TITLE
docs: fix nuxt.care badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Contributions are welcome. Please target the `next` branch for new features and 
 [install-size-href]: https://packagephobia.com/result?p=nuxt-directus-sdk
 
 [nuxt-care-src]: https://img.shields.io/endpoint?url=https%3A%2F%2Fnuxt.care%2Fapi%2Fv1%2Fbadge%3Fpackage%3Dnuxt-directus-sdk
-[nuxt-care-href]: https://nuxt.care/package/nuxt-directus-sdk
+[nuxt-care-href]: https://nuxt.care/?search=nuxt-directus-sdk
 
 [license-src]: https://img.shields.io/npm/l/nuxt-directus-sdk.svg?style=flat&colorA=18181B&colorB=28CF8D
 [license-href]: https://npmjs.com/package/nuxt-directus-sdk


### PR DESCRIPTION
### Summary

The current \`/package/nuxt-directus-sdk\` URL in the badge href 404s — nuxt.care doesn't have per-module detail pages. Detail views are a client-side slideover from the homepage.

Replaced with \`?search=nuxt-directus-sdk\` which pre-fills the homepage search input (confirmed working via the source repo's \`useModuleFilters\` composable). User lands on the homepage filtered to our module's card.

The badge image itself (showing 90/100) already worked — only the click-through was broken.

### Test plan

- [x] \`https://nuxt.care/?search=nuxt-directus-sdk\` loads and filters to the module
- [x] Targeting \`main\`