### PR TITLE
chore(ci): publish preview packages via pkg.pr.new

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,32 @@
+name: Preview packages (pkg.pr.new)
+
+on:
+  pull_request:
+  push:
+    branches: [next]
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # nuxt-module-build extends playground/.nuxt/tsconfig.json, so the
+      # playground has to be prepared before the package can be built.
+      - run: pnpm run dev:prepare
+
+      - run: pnpm run prepack
+
+      - run: pnpm dlx pkg-pr-new publish


### PR DESCRIPTION
### Summary

Adds a workflow that publishes a preview npm package for every PR and every push to \`next\` via [pkg.pr.new](https://pkg.pr.new).

Once merged, every open PR gets an automated comment with an install URL like:
\`\`\`
pnpm add https://pkg.pr.new/rolleyio/nuxt-directus-sdk@<sha>
\`\`\`

Contributors and maintainers can install the PR branch into a real Nuxt project to verify behaviour that in-tree tests can't catch — e.g. the devProxy fix in #91, where the bug only surfaces when the module is installed and bundled into a downstream app.

### Why

Three motivations:

1. **Test runtime fixes properly.** PR #91 touches the proxy server handler and runtime composables. Unit tests cover the cookie rewriter and the gating logic, but the actual install-and-run-in-staging flow needs a built artefact.
2. **Don't pollute the \`next\` dist-tag.** The alternative — cutting beta releases to test branches — leaves real version numbers in npm metadata even when the change is abandoned.
3. **Standard Nuxt ecosystem pattern.** Nuxt core, vue, vite, and most Nuxt modules already publish PR previews this way.

### Test plan

- [ ] Merge triggers a preview build for this PR itself
- [ ] PR #91 gets a comment with a preview URL once this lands
- [ ] Install URL resolves and can be installed into a downstream project
- [ ] \`pnpm lint\` and \`pnpm test\` pass locally (no code changes — workflow only)