### PR TITLE
fix(deps): relax @directus/sdk peer dep to v21 or v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "docs:preview": "vitepress preview docs"
   },
   "peerDependencies": {
-    "@directus/sdk": ">=22.0.0",
-    "@directus/types": ">=16.0.0",
-    "@directus/visual-editing": ">=2.1.0",
+    "@directus/sdk": ">=21.2.2",
+    "@directus/types": ">=15.0.2",
+    "@directus/visual-editing": ">=2.0.0",
     "@nuxt/image": ">=2.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
### Summary

v6.1.0 bumped the peer dep floor to \`@directus/sdk@>=22.0.0\`, which made projects on Directus 11 + SDK v21 see install warnings or have to pin back to v6.0.0. Closes #98 (raised by @snovik).

Loosens to \`>=21.2.2\` so both v21 and v22 are valid. Same for \`@directus/types\` (\`>=15.0.2\`) and \`@directus/visual-editing\` (\`>=2.0.0\`).

### Verified the module works on both

Ran the full test suite (lint, 352 tests, build) with \`@directus/sdk@21.3.0\` pinned. All green. The module's runtime is genuinely compatible with both majors:

- \`isDirectusError()\` works as a duck-typed guard on both — v21 rejects with a plain object that matches the shape, v22 throws a \`RequestError\` class that implements the same interface
- \`error.errors[].message\` / \`extensions.code\` shape is identical
- No v22-only SDK functions are called by the module

### Why only \`package.json\`

\`devDependencies\` stay on v22 so CI keeps validating against the newest SDK. The README's Directus version requirement stays as-is — the message "this module works with Directus 11+" is correct either way, and v7 (whenever it ships) will be the right moment to lift the SDK floor to v22-only.

### Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` clean against v22 (current devDeps) and v21 (verified separately)
- [x] \`pnpm prepack\` builds dist successfully
- [x] Targeting \`next\` branch