### PR TITLE
fix(deps): lower @directus/sdk peer dep floor to v21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "docs:preview": "vitepress preview docs"
   },
   "peerDependencies": {
-    "@directus/sdk": ">=21.2.2",
-    "@directus/types": ">=15.0.2",
+    "@directus/sdk": ">=21.0.0",
+    "@directus/types": ">=15.0.0",
     "@directus/visual-editing": ">=2.0.0",
     "@nuxt/image": ">=2.0.0"
   },


### PR DESCRIPTION
Quick follow-up to #99. v6.1.1 set the floor to `>=21.2.2` which was unnecessarily strict — the module's runtime works on any v21.x.y. Lowers to `>=21.0.0` to match v6.0.0's original floor.

Also lowers `@directus/types` to `>=15.0.0`.

### Test plan
- [x] Lint clean, 352 tests pass, builds successfully
- [x] Targeting `next`