### PR TITLE
chore: sync next to main for v6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v6.1.2
+
+[compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.1.1...v6.1.2)
+
+### 🩹 Fixes
+
+- **deps:** Lower @directus/sdk peer dep floor to v21.0.0 ([b7f959b](https://github.com/rolleyio/nuxt-directus-sdk/commit/b7f959b))
+
+### ❤️ Contributors
+
+- Matthew Rollinson <matt@rolley.io>
+
 ## v6.1.1
 
 [compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.1.0...v6.1.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v6.1.1
+
+[compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.1.0...v6.1.1)
+
+### 🩹 Fixes
+
+- **deps:** Relax @directus/sdk peer dep to v21 or v22 ([a07af5d](https://github.com/rolleyio/nuxt-directus-sdk/commit/a07af5d))
+
+### 📖 Documentation
+
+- Add missing deps bump entry to v6.1.0 changelog ([a762ba8](https://github.com/rolleyio/nuxt-directus-sdk/commit/a762ba8))
+
+### ❤️ Contributors
+
+- Matthew Rollinson <matt@rolley.io>
+
 ## v6.0.0...v6.1.0
 
 [compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.0.0...v6.1.0)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-directus-sdk",
   "type": "module",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "packageManager": "pnpm@10.32.1",
   "description": "A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.",
   "author": "Matthew Rollinson <matt@rolley.io>",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "docs:preview": "vitepress preview docs"
   },
   "peerDependencies": {
-    "@directus/sdk": ">=21.2.2",
-    "@directus/types": ">=15.0.2",
+    "@directus/sdk": ">=21.0.0",
+    "@directus/types": ">=15.0.0",
     "@directus/visual-editing": ">=2.0.0",
     "@nuxt/image": ">=2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-directus-sdk",
   "type": "module",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "packageManager": "pnpm@10.32.1",
   "description": "A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.",
   "author": "Matthew Rollinson <matt@rolley.io>",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
     "docs:preview": "vitepress preview docs"
   },
   "peerDependencies": {
-    "@directus/sdk": ">=22.0.0",
-    "@directus/types": ">=16.0.0",
-    "@directus/visual-editing": ">=2.1.0",
+    "@directus/sdk": ">=21.2.2",
+    "@directus/types": ">=15.0.2",
+    "@directus/visual-editing": ">=2.0.0",
     "@nuxt/image": ">=2.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Syncs \`next\` to \`main\` after the v6.1.1 + v6.1.2 patch releases.

### What landed since v6.1.0

- **v6.1.1** (#99) — relaxed \`@directus/sdk\` peer dep to allow v21 alongside v22 (fix for #98)
- **v6.1.2** (#100) — lowered the floor from \`>=21.2.2\` to \`>=21.0.0\` to match v6.0.0's original floor

Both are pure peer-dep adjustments. No runtime changes, no API changes.

### Test plan

- [x] v6.1.2 is live on npm \`latest\`
- [x] CI green on \`next\`