### PR TITLE
fix(proxy): strip the configured proxy.path instead of a hardcoded /directus prefix

### DIFF
--- a/src/runtime/server/routes/directus-proxy-path.ts
+++ b/src/runtime/server/routes/directus-proxy-path.ts
@@ -1,0 +1,9 @@
+export type ProxyConfig = boolean | { enabled?: boolean, path?: string, wsPath?: string }
+
+export function resolveProxyPath(proxy: ProxyConfig | undefined): string {
+  return (typeof proxy === 'object' && proxy.path) || '/directus'
+}
+
+export function stripProxyPrefix(pathname: string, proxyPath: string): string {
+  return pathname.startsWith(proxyPath) ? pathname.slice(proxyPath.length) : pathname
+}

--- a/src/runtime/server/routes/directus.ts
+++ b/src/runtime/server/routes/directus.ts
@@ -1,16 +1,22 @@
 import { useRuntimeConfig } from '#imports'
 import { defineEventHandler, getRequestIP, getRequestURL, proxyRequest, setResponseHeaders } from 'h3'
 import { joinURL } from 'ufo'
+import type { ProxyConfig } from './directus-proxy-path'
 import { rewriteProxiedSetCookie } from './directus-cookie'
+import { resolveProxyPath, stripProxyPrefix } from './directus-proxy-path'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const serverUrl = config.directus?.serverDirectusUrl
   const directusUrl = serverUrl || config.public.directus.directusUrl
 
+  // Strip the configured proxy mount path (not a hardcoded /directus) so
+  // custom `proxy.path` values forward the correct upstream URL.
+  const proxyPath = resolveProxyPath(config.public.directus.proxy as ProxyConfig)
+
   // Get the full URL path with query string
   const url = getRequestURL(event)
-  const path = url.pathname.replace(/^\/directus/, '') + url.search
+  const path = stripProxyPrefix(url.pathname, proxyPath) + url.search
 
   // Whether the request reaching us is HTTPS. We preserve Secure/SameSite=None
   // on HTTPS (production, staging) and downgrade only on HTTP (localhost dev).

--- a/test/proxy-path.test.ts
+++ b/test/proxy-path.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { resolveProxyPath, stripProxyPrefix } from '../src/runtime/server/routes/directus-proxy-path'
+
+describe('resolveProxyPath()', () => {
+  it('returns the configured path when proxy is an object with a path', () => {
+    expect(resolveProxyPath({ enabled: true, path: '/_content' })).toBe('/_content')
+  })
+
+  it('falls back to /directus when proxy is an object without a path', () => {
+    expect(resolveProxyPath({ enabled: true })).toBe('/directus')
+  })
+
+  it('falls back to /directus when proxy is a boolean', () => {
+    expect(resolveProxyPath(true)).toBe('/directus')
+    expect(resolveProxyPath(false)).toBe('/directus')
+  })
+
+  it('falls back to /directus when proxy is undefined', () => {
+    expect(resolveProxyPath(undefined)).toBe('/directus')
+  })
+})
+
+describe('stripProxyPrefix()', () => {
+  it('strips the default /directus prefix', () => {
+    expect(stripProxyPrefix('/directus/items/posts', '/directus')).toBe('/items/posts')
+  })
+
+  // Regression test for #102: a custom proxy.path was mounted correctly but
+  // never stripped, so the wrong URL was forwarded upstream.
+  it('strips a custom proxy path', () => {
+    expect(stripProxyPrefix('/_content/items/posts', '/_content')).toBe('/items/posts')
+  })
+
+  it('returns an empty path when the request hits the mount root', () => {
+    expect(stripProxyPrefix('/directus', '/directus')).toBe('')
+  })
+
+  it('leaves the pathname untouched when it does not start with the proxy path', () => {
+    expect(stripProxyPrefix('/other/items/posts', '/directus')).toBe('/other/items/posts')
+  })
+})


### PR DESCRIPTION
Fixes #102

## Problem

The proxy handler was mounted at the configured `proxy.path` (`addServerHandler({ route: \`${proxyPath}/**\` })`), but the runtime handler always stripped a hardcoded `/directus` literal. Any custom `proxy.path` therefore forwarded the wrong URL upstream: a request to `/_content/items/posts` was proxied as `http://directus:8055/_content/items/posts` instead of `http://directus:8055/items/posts`.

## Fix

- The handler now reads the configured path from `runtimeConfig.public.directus.proxy` and strips that, falling back to `/directus` so default behaviour is unchanged.
- The stripping logic is extracted into a pure helper (`directus-proxy-path.ts`) so it can be unit tested, following the same pattern as `directus-cookie.ts`.
- Uses `startsWith` + `slice` rather than a bare `slice(length)` so a non-matching pathname passes through untouched instead of being mangled.

## Tests

Added `test/proxy-path.test.ts` covering the regression (custom `/_content` path), the `/directus` default, boolean/undefined proxy config fallbacks, and non-matching pathnames. Full suite passes: 360 tests, no type errors, lint clean.

Thanks @neobutter for the detailed report and suggested fix.