### PR TITLE
chore: fix README alert syntax, add LICENSE, standardise example URLs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Matthew Rollinson <matt@rolley.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export default defineNuxtConfig({
 3. Create a `.env` file:
 
 ```dotenv
-DIRECTUS_URL=https://your-directus-url.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token # Optional: required for type generation
 ```
 
@@ -69,7 +69,7 @@ DIRECTUS_ADMIN_TOKEN=your_admin_token # Optional: required for type generation
 
 That's it! You can now use Directus within your Nuxt app ✨
 
-For cross-domain setups (e.g. `app.example.com` and `api.example.com`), see the [Authentication Guide](https://www.nuxt-directus-sdk.com/guide/authentication.html).
+For cross-domain setups (e.g. `app.example.com` and `directus.example.com`), see the [Authentication Guide](https://www.nuxt-directus-sdk.com/guide/authentication.html).
 
 ## CLI
 
@@ -90,7 +90,8 @@ See the [CLI documentation](https://www.nuxt-directus-sdk.com/api/configuration/
 
 ## Development
 
-> [!IMPORTANT] The playground uses the [directus-template-cli](https://github.com/directus-labs/directus-template-cli?tab=readme-ov-file#applying-a-template) `cms` template.
+> [!IMPORTANT]
+> The playground uses the [directus-template-cli](https://github.com/directus-labs/directus-template-cli?tab=readme-ov-file#applying-a-template) `cms` template.
 > Apply the template with `npx directus-template-cli@latest apply` and follow the interactive prompts.
 
 ```bash

--- a/docs/api/composables/auth.md
+++ b/docs/api/composables/auth.md
@@ -226,7 +226,7 @@ const { inviteUser } = useDirectusAuth()
 await inviteUser(
   'newuser@example.com',
   'role-uuid',
-  'https://yourapp.com/accept-invite'
+  'https://app.example.com/accept-invite'
 )
 ```
 
@@ -261,7 +261,7 @@ const { passwordRequest } = useDirectusAuth()
 
 await passwordRequest(
   'user@example.com',
-  'https://yourapp.com/reset-password'
+  'https://app.example.com/reset-password'
 )
 ```
 

--- a/docs/api/configuration/env.md
+++ b/docs/api/configuration/env.md
@@ -27,13 +27,13 @@ vercel env add DIRECTUS_ADMIN_TOKEN production
 **Netlify:**
 ```bash
 # In Netlify UI: Site settings → Environment variables
-DIRECTUS_URL=https://your-directus.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your-token
 ```
 
 **Docker:**
 ```dockerfile
-ENV DIRECTUS_URL=https://your-directus.com
+ENV DIRECTUS_URL=https://directus.example.com
 ENV DIRECTUS_ADMIN_TOKEN=your-token
 ```
 
@@ -43,7 +43,7 @@ When using Docker Compose, you can use the object URL form in `nuxt.config.ts` t
 export default defineNuxtConfig({
   directus: {
     url: {
-      client: 'https://cms.example.com',
+      client: 'https://directus.example.com',
       server: 'http://directus:8055', // Docker service name
     },
   }

--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
     // Core configuration — simple string
     url: process.env.DIRECTUS_URL,
     // Or split URLs for Docker/K8s:
-    // url: { client: 'https://cms.example.com', server: 'http://directus:8055' },
+    // url: { client: 'https://directus.example.com', server: 'http://directus:8055' },
     adminToken: process.env.DIRECTUS_ADMIN_TOKEN,
 
     // Development
@@ -96,11 +96,11 @@ Your Directus instance URL. Can be a simple string, or an object with separate `
 export default defineNuxtConfig({
   directus: {
     // Simple string — used everywhere
-    url: 'https://your-directus-instance.com',
+    url: 'https://directus.example.com',
 
     // Or split URLs for Docker/K8s
     url: {
-      client: 'https://cms.example.com', // Browser requests
+      client: 'https://directus.example.com', // Browser requests
       server: 'http://directus:8055', // SSR / server-side requests
     },
   },
@@ -110,7 +110,7 @@ export default defineNuxtConfig({
 Or use environment variable (string form only):
 
 ```dotenv
-DIRECTUS_URL=https://your-directus-instance.com
+DIRECTUS_URL=https://directus.example.com
 ```
 
 ::: tip When to use split URLs

--- a/docs/api/configuration/server.md
+++ b/docs/api/configuration/server.md
@@ -42,7 +42,7 @@ CORS_ORIGIN=http://localhost:3000
 
 ### Cross-Domain Setup
 
-If on different domains (e.g., app.example.com and api.example.com):
+If on different domains (e.g., app.example.com and directus.example.com):
 
 ```dotenv
 # Directus .env

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -55,13 +55,13 @@ For SSO to work with external redirects, you must add your frontend URL to the D
 
 ```dotenv
 # Directus .env
-AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST=https://yourapp.com,http://localhost:3000
+AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST=https://app.example.com,http://localhost:3000
 ```
 
 For example:
 ```dotenv
-AUTH_GOOGLE_REDIRECT_ALLOW_LIST=https://yourapp.com,http://localhost:3000
-AUTH_GITHUB_REDIRECT_ALLOW_LIST=https://yourapp.com,http://localhost:3000
+AUTH_GOOGLE_REDIRECT_ALLOW_LIST=https://app.example.com,http://localhost:3000
+AUTH_GITHUB_REDIRECT_ALLOW_LIST=https://app.example.com,http://localhost:3000
 ```
 
 This is a security setting in Directus to prevent open redirect vulnerabilities.
@@ -111,7 +111,7 @@ const newUser = await register({
 const { passwordRequest, passwordReset } = useDirectusAuth()
 
 // Request password reset
-await passwordRequest('user@example.com', 'https://yourapp.com/reset-password')
+await passwordRequest('user@example.com', 'https://app.example.com/reset-password')
 
 // Reset password with token
 await passwordReset('reset-token', 'new-password')
@@ -122,7 +122,7 @@ For password reset links to work with external domains, you must add them to the
 
 ```dotenv
 # Directus .env
-PASSWORD_RESET_URL_ALLOW_LIST=https://yourapp.com/auth/password-reset,http://localhost:3000/auth/password-reset
+PASSWORD_RESET_URL_ALLOW_LIST=https://app.example.com/auth/password-reset,http://localhost:3000/auth/password-reset
 ```
 
 This is a security setting in Directus to prevent open redirect vulnerabilities when users accept invitations.
@@ -134,7 +134,7 @@ This is a security setting in Directus to prevent open redirect vulnerabilities 
 const { inviteUser, acceptUserInvite } = useDirectusAuth()
 
 // Invite a user
-await inviteUser('newuser@example.com', 'role-id', 'https://yourapp.com/accept-invite')
+await inviteUser('newuser@example.com', 'role-id', 'https://app.example.com/accept-invite')
 
 // Accept invite
 await acceptUserInvite('invite-token', 'password')
@@ -145,7 +145,7 @@ For invite URLs to work with external domains, you must add them to the Directus
 
 ```dotenv
 # Directus .env
-USER_INVITE_URL_ALLOW_LIST=https://yourapp.com/accept-invite,http://localhost:3000/accept-invite
+USER_INVITE_URL_ALLOW_LIST=https://app.example.com/accept-invite,http://localhost:3000/accept-invite
 ```
 
 This is a security setting in Directus to prevent open redirect vulnerabilities when users accept invitations.
@@ -295,7 +295,7 @@ CORS_CREDENTIALS=true
 
 #### Cross-Domain Setup
 
-For production with separate domains (e.g., `app.example.com` and `api.example.com`):
+For production with separate domains (e.g., `app.example.com` and `directus.example.com`):
 
 ```dotenv
 # Directus .env

--- a/docs/guide/server-side.md
+++ b/docs/guide/server-side.md
@@ -562,7 +562,7 @@ Get the full Directus URL for a given path. On the server, this prefers the `ser
 **Example:**
 ```typescript
 const assetsUrl = useDirectusUrl('assets')
-// With simple URL: https://your-directus.com/assets
+// With simple URL: https://directus.example.com/assets
 // With split URL: http://directus:8055/assets (uses internal server URL)
 ```
 

--- a/docs/guide/type-generation.md
+++ b/docs/guide/type-generation.md
@@ -7,7 +7,7 @@ The module generates TypeScript types from your Directus schema at build time, s
 Type generation is enabled by default. Set `DIRECTUS_ADMIN_TOKEN` in your `.env`:
 
 ```dotenv
-DIRECTUS_URL=https://your-directus-instance.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token
 ```
 

--- a/docs/guide/visual-editor.md
+++ b/docs/guide/visual-editor.md
@@ -28,7 +28,7 @@ When `visualEditor: true` is set in your config (the default), the module:
 // nuxt.config.ts
 export default defineNuxtConfig({
   directus: {
-    url: 'https://your-directus-instance.com',
+    url: 'https://directus.example.com',
     visualEditor: true, // This is the default
   },
 })
@@ -305,7 +305,7 @@ const { data: page } = await useAsyncData('page', () =>
 Add `?debug` to any page URL to enable debug logging for the visual editor:
 
 ```
-https://yourapp.com/blog/my-post?debug
+https://app.example.com/blog/my-post?debug
 ```
 
 This outputs detailed logs to the browser console:
@@ -315,7 +315,7 @@ This outputs detailed logs to the browser console:
 [Directus Plugin] Is in iframe: true
 [Directus Visual Editor] Config visualEditor: true
 [Directus Visual Editor] Is in iframe: true
-[Directus Visual Editor] Directus URL: https://your-directus.com
+[Directus Visual Editor] Directus URL: https://directus.example.com
 [Directus Visual Editor] MutationObserver started, waiting for [data-directus] elements
 [Directus Visual Editor] MutationObserver: found 12 [data-directus] elements
 [Directus Visual Editor] Calling apply()...
@@ -424,7 +424,7 @@ const directusVisualEditor = useDirectusVisualEditor()
 
 The `apply()` function uses `postMessage` to handshake with the Directus parent frame. If it returns `false`:
 
-1. **URL mismatch** — The `url` in your nuxt.config must match the exact origin of the Directus admin panel. For example, if your Directus admin is at `https://api.example.com` but your config points to `https://directus.fly.dev`, the handshake will fail
+1. **URL mismatch** — The `url` in your nuxt.config must match the exact origin of the Directus admin panel. For example, if your Directus admin is at `https://directus.example.com` but your config points to `https://directus.fly.dev`, the handshake will fail
 2. **CORS issues** — Ensure your Directus instance allows your Nuxt app origin
 3. **CSP restrictions** — Check that `Content-Security-Policy` allows `frame-ancestors` from your Directus origin
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ export default defineNuxtConfig({
 
 ```dotenv
 # .env
-DIRECTUS_URL=https://your-directus-instance.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token
 ```
 

--- a/playground/pages/data/auto-import.vue
+++ b/playground/pages/data/auto-import.vue
@@ -69,7 +69,7 @@ const globals = await directus.request(readSingleton('globals'))</pre>
 
       <pre class="bg-elevated border border-default rounded p-4 text-xs overflow-x-auto mb-3">import { createDirectus, rest, staticToken } from '@directus/sdk'
 
-const publicClient = createDirectus('https://your-directus.example.com')
+const publicClient = createDirectus('https://directus.example.com')
   .with(staticToken('your-static-token'))
   .with(rest())
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -44,8 +44,8 @@ export interface ModuleOptions {
    * Can be a string for a single URL, or an object with `client` and `server` for split URLs.
    * Use the object form in Docker/K8s where SSR needs an internal hostname.
    * @default process.env.DIRECTUS_URL
-   * @example 'https://cms.example.com'
-   * @example { client: 'https://cms.example.com', server: 'http://cms_directus:8055' }
+   * @example 'https://directus.example.com'
+   * @example { client: 'https://directus.example.com', server: 'http://directus:8055' }
    */
   url: DirectusUrl
 


### PR DESCRIPTION
Fixes #94

Addresses the three housekeeping items @kheiner spotted:

## `[!IMPORTANT]` not rendering

GitHub only renders the alert when the marker sits on its own line. The README had the text on the same line as the tag, so it displayed as literal `[!IMPORTANT]` text. Now split across lines.

## Missing licence

`package.json` declares MIT but the repo had no license file, which is why nuxt.care reported none. Added a standard MIT `LICENSE` file (npm also picks this up automatically for the published package).

## Inconsistent example URLs

Standardised placeholders across the README, docs, playground, and JSDoc examples:

- Directus instance: `directus.example.com` (was a mix of `your-directus.com`, `your-directus-instance.com`, `your-directus-url.com`, `cms.example.com`, and `api.example.com`)
- App origin: `app.example.com` (was `yourapp.com` in places)

Deliberate distinctions are kept: `staging.example.com`/`production.example.com` in the rules-sync docs, `http://directus:8055` for Docker-internal networking, `localhost` URLs, and the distinct hostnames used in test fixtures.

Lint and the full test suite pass (352 tests, no type errors).