### PR TITLE
fix(rules): remap local policy IDs by name before comparing payloads

### DIFF
--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -83,6 +83,7 @@ export type {
 } from './sync'
 
 export {
+  alignLocalIdsToRemote,
   compareRulesPayloads,
   diffRemoteRules,
   diffRules,

--- a/src/rules/sync/diff.ts
+++ b/src/rules/sync/diff.ts
@@ -244,6 +244,71 @@ function isInternalSystemCollection(collection: string): boolean {
 }
 
 /**
+ * Remap local policy/role IDs onto remote IDs by matching entity names.
+ *
+ * Code-authored rules assign ephemeral UUIDs in {@link serializeToDirectusApi}.
+ * Roles and policies are matched by name, but permissions are keyed by
+ * `` `${policyId}:${collection}:${action}` `` and role equality compares
+ * policy ID arrays. Without remapping, semantically identical local/remote
+ * states always appear as delete+create for permissions and modified roles.
+ *
+ * Returns a shallow-cloned local payload with IDs rewritten where a remote
+ * counterpart with the same name exists. The input is never mutated.
+ */
+export function alignLocalIdsToRemote(
+  local: DirectusRulesPayload,
+  remote: DirectusRulesPayload,
+): DirectusRulesPayload {
+  const remotePolicyIdByName = new Map<string, string>()
+  for (const policy of remote.policies) {
+    if (policy.name && policy.id)
+      remotePolicyIdByName.set(policy.name, policy.id)
+  }
+
+  const remoteRoleIdByName = new Map<string, string>()
+  for (const role of remote.roles) {
+    if (role.name && role.id)
+      remoteRoleIdByName.set(role.name, role.id)
+  }
+
+  const localPolicyIdToRemote = new Map<string, string>()
+  for (const policy of local.policies) {
+    if (!policy.id)
+      continue
+    const remoteId = remotePolicyIdByName.get(policy.name)
+    if (remoteId)
+      localPolicyIdToRemote.set(policy.id, remoteId)
+  }
+
+  const mapPolicyId = (id: string | null | undefined): string | null | undefined => {
+    if (id == null)
+      return id
+    return localPolicyIdToRemote.get(id) ?? id
+  }
+
+  return {
+    roles: local.roles.map(role => ({
+      ...role,
+      id: (role.id && remoteRoleIdByName.get(role.name)) || role.id,
+      parent: role.parent
+        ? (remoteRoleIdByName.get(
+            local.roles.find(r => r.id === role.parent)?.name ?? '',
+          ) ?? remoteRoleIdByName.get(role.parent) ?? role.parent)
+        : role.parent,
+      policies: role.policies?.map(id => mapPolicyId(id) ?? id),
+    })),
+    policies: local.policies.map(policy => ({
+      ...policy,
+      id: (policy.id && remotePolicyIdByName.get(policy.name)) || policy.id,
+    })),
+    permissions: local.permissions.map(permission => ({
+      ...permission,
+      policy: mapPolicyId(permission.policy) ?? permission.policy,
+    })),
+  }
+}
+
+/**
  * Compare two DirectusRulesPayload objects and generate diff
  *
  * Exported for testing and direct use when you already have both payloads.
@@ -266,14 +331,18 @@ export function compareRulesPayloads(
 ): RulesDiff {
   const { excludeSystemCollections = true } = options
 
-  const roles = compareRoles(local.roles, remote.roles)
-  const policies = comparePolicies(local.policies, remote.policies)
+  // Align local policy/role IDs to remote by name so code-authored rules
+  // (random UUIDs) converge with a live instance on subsequent syncs.
+  const alignedLocal = alignLocalIdsToRemote(local, remote)
+
+  const roles = compareRoles(alignedLocal.roles, remote.roles)
+  const policies = comparePolicies(alignedLocal.policies, remote.policies)
 
   // Filter permissions:
   // - Exclude internal system collections if option is set
   // - Always exclude permissions with policy: null (these are Directus "app access" permissions
   //   that aren't managed through the rules DSL)
-  const localPerms = local.permissions.filter((p) => {
+  const localPerms = alignedLocal.permissions.filter((p) => {
     if (p.policy === null)
       return false
     if (excludeSystemCollections && isInternalSystemCollection(p.collection))

--- a/src/rules/sync/diff.ts
+++ b/src/rules/sync/diff.ts
@@ -243,6 +243,26 @@ function isInternalSystemCollection(collection: string): boolean {
   return EXCLUDED_SYSTEM_COLLECTIONS.has(collection)
 }
 
+function countByName(entities: Array<{ name: string }>): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const entity of entities) {
+    if (entity.name)
+      counts.set(entity.name, (counts.get(entity.name) ?? 0) + 1)
+  }
+  return counts
+}
+
+/** Name -> ID map limited to names that appear exactly once. */
+function uniqueNameIdMap(entities: Array<{ name: string, id?: string }>): Map<string, string> {
+  const counts = countByName(entities)
+  const map = new Map<string, string>()
+  for (const entity of entities) {
+    if (entity.name && entity.id && counts.get(entity.name) === 1)
+      map.set(entity.name, entity.id)
+  }
+  return map
+}
+
 /**
  * Remap local policy/role IDs onto remote IDs by matching entity names.
  *
@@ -252,28 +272,26 @@ function isInternalSystemCollection(collection: string): boolean {
  * policy ID arrays. Without remapping, semantically identical local/remote
  * states always appear as delete+create for permissions and modified roles.
  *
- * Returns a shallow-cloned local payload with IDs rewritten where a remote
- * counterpart with the same name exists. The input is never mutated.
+ * Names are the only join key, and Directus does not enforce unique role or
+ * policy names. A name that appears more than once on either side is
+ * ambiguous, so those entities are left untouched instead of risking a remap
+ * onto the wrong entity.
+ *
+ * Returns a shallow-cloned local payload with IDs rewritten where a unique
+ * remote counterpart with the same name exists. The input is never mutated.
  */
 export function alignLocalIdsToRemote(
   local: DirectusRulesPayload,
   remote: DirectusRulesPayload,
 ): DirectusRulesPayload {
-  const remotePolicyIdByName = new Map<string, string>()
-  for (const policy of remote.policies) {
-    if (policy.name && policy.id)
-      remotePolicyIdByName.set(policy.name, policy.id)
-  }
-
-  const remoteRoleIdByName = new Map<string, string>()
-  for (const role of remote.roles) {
-    if (role.name && role.id)
-      remoteRoleIdByName.set(role.name, role.id)
-  }
+  const remotePolicyIdByName = uniqueNameIdMap(remote.policies)
+  const remoteRoleIdByName = uniqueNameIdMap(remote.roles)
+  const localPolicyNameCounts = countByName(local.policies)
+  const localRoleNameCounts = countByName(local.roles)
 
   const localPolicyIdToRemote = new Map<string, string>()
   for (const policy of local.policies) {
-    if (!policy.id)
+    if (!policy.id || localPolicyNameCounts.get(policy.name) !== 1)
       continue
     const remoteId = remotePolicyIdByName.get(policy.name)
     if (remoteId)
@@ -286,20 +304,28 @@ export function alignLocalIdsToRemote(
     return localPolicyIdToRemote.get(id) ?? id
   }
 
+  const mapRoleId = (role: { id?: string, name: string }): string | undefined => {
+    if (!role.id || localRoleNameCounts.get(role.name) !== 1)
+      return role.id
+    return remoteRoleIdByName.get(role.name) ?? role.id
+  }
+
   return {
-    roles: local.roles.map(role => ({
-      ...role,
-      id: (role.id && remoteRoleIdByName.get(role.name)) || role.id,
-      parent: role.parent
-        ? (remoteRoleIdByName.get(
-            local.roles.find(r => r.id === role.parent)?.name ?? '',
-          ) ?? remoteRoleIdByName.get(role.parent) ?? role.parent)
-        : role.parent,
-      policies: role.policies?.map(id => mapPolicyId(id) ?? id),
-    })),
+    roles: local.roles.map((role) => {
+      const parentRole = role.parent ? local.roles.find(r => r.id === role.parent) : undefined
+
+      return {
+        ...role,
+        id: mapRoleId(role),
+        parent: role.parent
+          ? ((parentRole && mapRoleId(parentRole)) ?? remoteRoleIdByName.get(role.parent) ?? role.parent)
+          : role.parent,
+        policies: role.policies?.map(id => mapPolicyId(id) ?? id),
+      }
+    }),
     policies: local.policies.map(policy => ({
       ...policy,
-      id: (policy.id && remotePolicyIdByName.get(policy.name)) || policy.id,
+      id: (policy.id && localPolicyNameCounts.get(policy.name) === 1 && remotePolicyIdByName.get(policy.name)) || policy.id,
     })),
     permissions: local.permissions.map(permission => ({
       ...permission,

--- a/src/rules/sync/index.ts
+++ b/src/rules/sync/index.ts
@@ -4,7 +4,7 @@
 
 export type { CompareOptions } from './diff'
 
-export { compareRulesPayloads, diffRemoteRules, diffRules, fetchRemoteRules, fetchRemoteRulesAsJson, pullRules } from './diff'
+export { alignLocalIdsToRemote, compareRulesPayloads, diffRemoteRules, diffRules, fetchRemoteRules, fetchRemoteRulesAsJson, pullRules } from './diff'
 export { formatDiff } from './format'
 export { formatPushResult, pushRules } from './push'
 export type {

--- a/test/rules/sync.test.ts
+++ b/test/rules/sync.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../src/rules'
 import { describe, expect, it } from 'vitest'
 import {
+  alignLocalIdsToRemote,
   compareRulesPayloads,
   formatDiff,
   formatPushResult,
@@ -834,5 +835,82 @@ describe('sync: name-based policy ID alignment', () => {
     expect(diff.summary.roles.modified).toBe(0)
     expect(diff.summary.permissions.added).toBe(0)
     expect(diff.summary.permissions.removed).toBe(0)
+  })
+
+  it('does not remap when a remote policy name is duplicated', () => {
+    // Directus does not enforce unique policy names. Remapping onto either
+    // duplicate could target the wrong entity, so ambiguous names are left as-is.
+    const basePolicy = {
+      name: 'Content',
+      icon: 'article',
+      description: null,
+      ip_access: null,
+      enforce_tfa: false,
+      admin_access: false,
+      app_access: true,
+    }
+
+    const local: DirectusRulesPayload = {
+      roles: [],
+      policies: [{ ...basePolicy, id: 'local-policy-uuid' }],
+      permissions: [{
+        policy: 'local-policy-uuid',
+        collection: 'posts',
+        action: 'read',
+        permissions: null,
+        validation: null,
+        presets: null,
+        fields: ['*'],
+      }],
+    }
+
+    const remote: DirectusRulesPayload = {
+      roles: [],
+      policies: [
+        { ...basePolicy, id: 'remote-policy-a' },
+        { ...basePolicy, id: 'remote-policy-b' },
+      ],
+      permissions: [],
+    }
+
+    const aligned = alignLocalIdsToRemote(local, remote)
+
+    expect(aligned.policies[0]!.id).toBe('local-policy-uuid')
+    expect(aligned.permissions[0]!.policy).toBe('local-policy-uuid')
+  })
+
+  it('does not remap when a local name is duplicated', () => {
+    const basePolicy = {
+      name: 'Content',
+      icon: 'article',
+      description: null,
+      ip_access: null,
+      enforce_tfa: false,
+      admin_access: false,
+      app_access: true,
+    }
+
+    const local: DirectusRulesPayload = {
+      roles: [
+        { id: 'local-role-a', name: 'Editor', icon: 'edit', description: null, parent: null },
+        { id: 'local-role-b', name: 'Editor', icon: 'edit', description: null, parent: null },
+      ],
+      policies: [
+        { ...basePolicy, id: 'local-policy-a' },
+        { ...basePolicy, id: 'local-policy-b' },
+      ],
+      permissions: [],
+    }
+
+    const remote: DirectusRulesPayload = {
+      roles: [{ id: 'remote-role', name: 'Editor', icon: 'edit', description: null, parent: null }],
+      policies: [{ ...basePolicy, id: 'remote-policy' }],
+      permissions: [],
+    }
+
+    const aligned = alignLocalIdsToRemote(local, remote)
+
+    expect(aligned.roles.map(r => r.id)).toEqual(['local-role-a', 'local-role-b'])
+    expect(aligned.policies.map(p => p.id)).toEqual(['local-policy-a', 'local-policy-b'])
   })
 })

--- a/test/rules/sync.test.ts
+++ b/test/rules/sync.test.ts
@@ -763,3 +763,76 @@ describe('sync: round-trip payload consistency', () => {
     expect(diff.hasChanges).toBe(false)
   })
 })
+
+describe('sync: name-based policy ID alignment', () => {
+  it('treats semantically identical rules as unchanged when local policy UUIDs differ', () => {
+    // Remote IDs come from Directus. Local IDs come from serializeToDirectusApi
+    // assigning random UUIDs when defineDirectusRules has no explicit ids.
+    const local: DirectusRulesPayload = {
+      roles: [{
+        name: 'Editor',
+        icon: 'edit',
+        description: null,
+        parent: null,
+        policies: ['local-policy-uuid'],
+      }],
+      policies: [{
+        id: 'local-policy-uuid',
+        name: 'Content',
+        icon: 'article',
+        description: null,
+        ip_access: null,
+        enforce_tfa: false,
+        admin_access: false,
+        app_access: true,
+      }],
+      permissions: [{
+        policy: 'local-policy-uuid',
+        collection: 'posts',
+        action: 'read',
+        permissions: null,
+        validation: null,
+        presets: null,
+        fields: ['*'],
+      }],
+    }
+
+    const remote: DirectusRulesPayload = {
+      roles: [{
+        id: 'remote-role',
+        name: 'Editor',
+        icon: 'edit',
+        description: null,
+        parent: null,
+        policies: ['remote-policy-uuid'],
+      }],
+      policies: [{
+        id: 'remote-policy-uuid',
+        name: 'Content',
+        icon: 'article',
+        description: null,
+        ip_access: null,
+        enforce_tfa: false,
+        admin_access: false,
+        app_access: true,
+      }],
+      permissions: [{
+        id: 42,
+        policy: 'remote-policy-uuid',
+        collection: 'posts',
+        action: 'read',
+        permissions: null,
+        validation: null,
+        presets: null,
+        fields: ['*'],
+      }],
+    }
+
+    const diff = compareRulesPayloads(local, remote)
+
+    expect(diff.hasChanges).toBe(false)
+    expect(diff.summary.roles.modified).toBe(0)
+    expect(diff.summary.permissions.added).toBe(0)
+    expect(diff.summary.permissions.removed).toBe(0)
+  })
+})


### PR DESCRIPTION
## Problem

Roles and policies are matched by **name**, but permissions are keyed by `` `${policyId}:${collection}:${action}` `` and role equality compares policy ID arrays. Code-authored rules via `defineDirectusRules` have no stable IDs, so `serializeToDirectusApi` assigns random UUIDs every run.

Result: semantic-identical local and remote state always diffs as permission delete+create and modified roles. Repeated `pushRules` does not converge; with `--skip-deletes` it piles up duplicate permission rows.

The pull → edit → push JSON path works only because pulled files carry remote IDs.

## Fix

Before comparing, `compareRulesPayloads` remaps local policy/role IDs onto remote IDs by matching entity **names** (`alignLocalIdsToRemote`). Input payloads are not mutated.

## Tests

Added a regression case: local ephemeral UUID + remote UUID for the same policy name → empty diff (no permission thrash, no role modified).

## Notes

Independent of delete-safety defaults (`fix/rules-delete-guards`); merge either order is fine, though both are recommended for push safety.