### PR TITLE
fix(auth): honour guest middleware under global auth middleware

### DIFF
--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -5,22 +5,36 @@ import {
   useRuntimeConfig,
 } from '#imports'
 
+function hasGuestMeta(to: { meta?: Record<string, unknown> }): boolean {
+  const middleware = to.meta?.middleware
+  if (!middleware)
+    return false
+  if (middleware === 'guest')
+    return true
+  return Array.isArray(middleware) && middleware.includes('guest')
+}
+
 export default defineNuxtRouteMiddleware((to) => {
   const config = useRuntimeConfig()
   const user = useDirectusUser()
 
   const redirect = config.public.directus.auth?.redirect ?? {}
-  const loginPath = redirect.login ?? '/login'
+  const loginPath = redirect.login ?? '/auth/login'
   const homePath = redirect.home ?? '/'
 
   if (to.path === loginPath) {
     return
   }
 
+  // Named `guest` middleware marks public pages when global auth is enabled.
+  if (hasGuestMeta(to)) {
+    return
+  }
+
   if (!user.value) {
     return navigateTo({
       path: loginPath,
-      query: { redirect: to.path !== homePath ? encodeURIComponent(to.path) : undefined },
+      query: { redirect: to.path !== homePath ? encodeURIComponent(to.fullPath) : undefined },
     })
   }
 })

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -34,7 +34,7 @@ export default defineNuxtRouteMiddleware((to) => {
   if (!user.value) {
     return navigateTo({
       path: loginPath,
-      query: { redirect: to.path !== homePath ? encodeURIComponent(to.fullPath) : undefined },
+      query: { redirect: to.fullPath !== homePath ? encodeURIComponent(to.fullPath) : undefined },
     })
   }
 })

--- a/src/runtime/middleware/guest.ts
+++ b/src/runtime/middleware/guest.ts
@@ -1,6 +1,23 @@
-import { defineNuxtRouteMiddleware } from '#imports'
+import { defineNuxtRouteMiddleware, navigateTo, useDirectusUser, useRuntimeConfig } from '#imports'
 
-export default defineNuxtRouteMiddleware(() => {
-  // Allow access without authentication
-  // This middleware is used to mark pages as public when global auth is enabled
+/**
+ * Mark a page as public when global auth middleware is enabled.
+ * Auth middleware short-circuits when route meta includes this name.
+ *
+ * When a logged-in user hits a pure guest page (e.g. login), redirect home
+ * if they are already authenticated — but only when this middleware is used
+ * alone on the login route. Visitor-only pages that simply need to stay
+ * public should use `middleware: 'guest'` and leave users as-is.
+ */
+export default defineNuxtRouteMiddleware((to) => {
+  const user = useDirectusUser()
+  const config = useRuntimeConfig()
+  const loginPath = config.public.directus.auth?.redirect?.login ?? '/auth/login'
+  const homePath = config.public.directus.auth?.redirect?.home ?? '/'
+
+  // Allow access without authentication (global auth checks this name).
+  // Optionally bounce authenticated users away from the login page itself.
+  if (user.value && to.path === loginPath) {
+    return navigateTo(homePath)
+  }
 })


### PR DESCRIPTION
## Problem

`guest` middleware was a documented no-op. With `enableGlobalAuthMiddleware: true`, every route except the login path redirected to login — including pages marked `middleware: 'guest'`.

Auth middleware also fell back to `/login` (module default is `/auth/login`) and stored only `to.path`, dropping the query string from the post-login redirect.

## Fix

- Global `auth` middleware treats route meta that includes `guest` as public.
- Default login path aligned to `/auth/login`.
- Redirect query uses `to.fullPath` so query (and hash segment handling via fullPath) is preserved.
- `guest` can bounce already-authenticated users off the login path to home.