### PR TITLE
fix(auth): validate post-login redirects and preserve fullPath

### DIFF
--- a/src/runtime/composables/auth.ts
+++ b/src/runtime/composables/auth.ts
@@ -16,6 +16,7 @@ import {
   updateMe as directusUpdateMe,
 } from '@directus/sdk'
 import { joinURL, withoutTrailingSlash } from 'ufo'
+import { resolveSafeRedirectPath } from '../utils/redirect'
 import { useDirectus, useDirectusOriginUrl } from './directus'
 
 /**
@@ -118,7 +119,8 @@ export function useDirectusAuth(): DirectusAuth {
         await navigateTo(redirect)
       }
       else if (route?.query?.redirect) {
-        await navigateTo({ path: decodeURIComponent(route.query.redirect as string) })
+        const home = config.public.directus.auth?.redirect?.home ?? '/'
+        await navigateTo(resolveSafeRedirectPath(route.query.redirect, home))
       }
       else {
         await navigateTo(config.public.directus.auth?.redirect?.home ?? '/')

--- a/src/runtime/middleware/auth.ts
+++ b/src/runtime/middleware/auth.ts
@@ -10,7 +10,7 @@ export default defineNuxtRouteMiddleware((to) => {
   const user = useDirectusUser()
 
   const redirect = config.public.directus.auth?.redirect ?? {}
-  const loginPath = redirect.login ?? '/login'
+  const loginPath = redirect.login ?? '/auth/login'
   const homePath = redirect.home ?? '/'
 
   if (to.path === loginPath) {
@@ -20,7 +20,7 @@ export default defineNuxtRouteMiddleware((to) => {
   if (!user.value) {
     return navigateTo({
       path: loginPath,
-      query: { redirect: to.path !== homePath ? encodeURIComponent(to.path) : undefined },
+      query: { redirect: to.fullPath !== homePath ? encodeURIComponent(to.fullPath) : undefined },
     })
   }
 })

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -6,6 +6,8 @@ export function useUrl(base: string, ...paths: string[]): string {
   return cleanDoubleSlashes(withTrailingSlash(joinURL(base, '/', ...paths)))
 }
 
+export { isSafeRedirectPath, resolveSafeRedirectPath } from './redirect'
+
 export function isQueryParamEnabled(value: unknown) {
   return value === 'true' || value === '1' || value === true || value === 1
 }

--- a/src/runtime/utils/redirect.ts
+++ b/src/runtime/utils/redirect.ts
@@ -1,0 +1,34 @@
+/**
+ * Validate post-login redirect targets.
+ * Allows same-origin path-only redirects; rejects schemes and //evil.com.
+ */
+export function isSafeRedirectPath(value: unknown): value is string {
+  if (typeof value !== 'string' || !value)
+    return false
+  const path = value.startsWith('/') ? value : (() => {
+    try {
+      return decodeURIComponent(value)
+    }
+    catch {
+      return ''
+    }
+  })()
+  if (!path.startsWith('/') || path.startsWith('//'))
+    return false
+  if (path.includes('://') || path.includes('\\'))
+    return false
+  return true
+}
+
+export function resolveSafeRedirectPath(value: unknown, fallback = '/'): string {
+  if (typeof value !== 'string' || !value)
+    return fallback
+  let decoded = value
+  try {
+    decoded = decodeURIComponent(value)
+  }
+  catch {
+    return fallback
+  }
+  return isSafeRedirectPath(decoded) ? decoded : fallback
+}

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -249,7 +249,7 @@ describe('useDirectusAuth', () => {
 
       await useDirectusAuth().login('user@example.com', 'secret')
 
-      expect(navigateToMock).toHaveBeenCalledWith({ path: '/dashboard' })
+      expect(navigateToMock).toHaveBeenCalledWith('/dashboard')
     })
 
     it('redirects to the provided RouteLocationRaw when redirect option is a non-boolean', async () => {

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { isSafeRedirectPath, resolveSafeRedirectPath } from '../src/runtime/utils/redirect'
+
+describe('isSafeRedirectPath', () => {
+  it('allows absolute same-origin paths', () => {
+    expect(isSafeRedirectPath('/dashboard')).toBe(true)
+    expect(isSafeRedirectPath('/posts?x=1')).toBe(true)
+    expect(isSafeRedirectPath('/a/b#hash')).toBe(true)
+  })
+
+  it('rejects protocol-relative and absolute URLs', () => {
+    expect(isSafeRedirectPath('//evil.com')).toBe(false)
+    expect(isSafeRedirectPath('https://evil.com')).toBe(false)
+    expect(isSafeRedirectPath('javascript:alert(1)')).toBe(false)
+  })
+})
+
+describe('resolveSafeRedirectPath', () => {
+  it('decodes and validates encoded paths', () => {
+    expect(resolveSafeRedirectPath(encodeURIComponent('/dashboard'))).toBe('/dashboard')
+  })
+
+  it('falls back for unsafe values', () => {
+    expect(resolveSafeRedirectPath('//evil.com', '/')).toBe('/')
+    expect(resolveSafeRedirectPath('https://evil.com', '/home')).toBe('/home')
+  })
+})


### PR DESCRIPTION
## Problem

After login, `route.query.redirect` was decoded and passed to `navigateTo` with no allowlist. Crafted values like `//evil.com` or absolute URLs are an open-redirect risk.

Auth middleware also dropped the query string (`to.path` only) and defaulted login to `/login` instead of `/auth/login`.

## Fix

- New helpers `isSafeRedirectPath` / `resolveSafeRedirectPath` — same-origin path only, reject `//`, schemes, backslashes.
- Login uses the safe resolver with home as fallback.
- Middleware default login path `/auth/login`; redirect stores `to.fullPath`.
- Unit tests for redirect sanitization; auth tests updated for the string navigate form.