### PR TITLE
fix(preview): share live-preview token so SSR clients apply it

### DIFF
--- a/src/runtime/composables/directus.ts
+++ b/src/runtime/composables/directus.ts
@@ -9,6 +9,11 @@ export function useDirectusPreview(): Ref<boolean> {
   return useState('directus.preview', () => false)
 }
 
+/** Live-preview static token from `?token=`; shared so SSR + client clients apply it. */
+export function useDirectusPreviewToken(): Ref<string | null> {
+  return useState<string | null>('directus.previewToken', () => null)
+}
+
 export function useDirectusVisualEditor(): Ref<boolean> {
   return useState('directus.visualEditor', () => false)
 }
@@ -132,6 +137,12 @@ function createDirectusClient() {
       authMode: authConfig.realtimeAuthMode as WebSocketAuthModes || 'public',
       ...(realtimeUrl ? { url: realtimeUrl } : {}),
     }))
+
+  // Apply shared preview token so SSR component fetches see live preview too
+  // (plugin.setToken alone only hit the first server client instance).
+  const previewToken = useDirectusPreviewToken().value
+  if (previewToken)
+    directus.setToken(previewToken)
 
   return directus
 }

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,6 +1,6 @@
 import { defineNuxtPlugin, refreshNuxtData, useCookie, useRoute, useRuntimeConfig } from '#app'
 import { useDirectusAuth } from './composables/auth'
-import { useDirectus, useDirectusOriginUrl, useDirectusPreview, useDirectusVisualEditor } from './composables/directus'
+import { useDirectus, useDirectusOriginUrl, useDirectusPreview, useDirectusPreviewToken, useDirectusVisualEditor } from './composables/directus'
 import { isQueryParamEnabled } from './utils'
 
 export default defineNuxtPlugin({
@@ -31,10 +31,13 @@ export default defineNuxtPlugin({
     }
 
     if (directusPreview.value) {
-      // If we are in preview mode, we need to use the token from the query string
+      // Live preview: store token in shared state so every useDirectus() client
+      // (including per-request SSR instances) applies it in createDirectusClient.
       const token = route.query.token as string | undefined
+      const previewToken = useDirectusPreviewToken()
 
       if (token) {
+        previewToken.value = token
         directus.setToken(token)
         log('Preview token set')
 


### PR DESCRIPTION
## Problem

The plugin called `setToken(token)` on a single Directus client. On the server, `useDirectus()` creates a **fresh client per call**, so SSR component fetches never saw the `?token=` live-preview token. Preview only worked after client-side `refreshNuxtData()`.

## Fix

- Store the preview token in `useState` (`useDirectusPreviewToken`).
- Apply it inside `createDirectusClient` so every server/client instance picks it up.
- Plugin still sets the token on its client for immediate use and keeps the `page:finish` refresh.