### PR TITLE
fix(files): append per-file metadata instead of formData.set

### DIFF
--- a/src/runtime/composables/files.ts
+++ b/src/runtime/composables/files.ts
@@ -24,7 +24,8 @@ export async function uploadDirectusFiles(files: DirectusFileUpload[], query?: Q
   files.forEach(({ file, data }) => {
     if (data) {
       Object.entries(data).forEach(([key, value]) => {
-        if (value !== undefined) formData.set(key, value)
+        if (value !== undefined)
+          formData.append(key, value)
       })
     }
 


### PR DESCRIPTION
## Problem

Multi-file uploads used `FormData.set()` for metadata before each `append('file', …)`. `set` replaces an existing key at its original position, so a second file’s fields overwrote metadata for the first and the second file got none. Directus expects each file’s fields to precede its file part as separate `append`s.

## Fix

Use `formData.append(key, value)` for per-file metadata sequence integrity.