### PR TITLE
fix(devtools): embed Directus admin via client URL

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -606,7 +606,8 @@ export default defineNuxtModule<ModuleOptions>({
           icon: 'simple-icons:directus',
           view: {
             type: 'iframe',
-            src: useUrl(directusUrl, 'admin'),
+            // Browser must open the public client URL, not an internal Docker/K8s hostname.
+            src: useUrl(clientUrl || directusUrl, 'admin'),
           },
         })
       })


### PR DESCRIPTION
## Problem

Nuxt DevTools iframe used the server-side Directus URL (`server` half of split config, or Docker-internal hostname). The browser cannot load `http://directus:8055/admin` when client and server URLs differ.

## Fix

Point the DevTools iframe at the **client** URL (`clientUrl || directusUrl`), matching how the visual editor already resolves origin.