### PR TITLE
feat: data fetching composables with Pinia Colada queries and experimental data loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ coverage
 Network Trash Folder
 Temporary Items
 .apdisk
+.playwright-mcp

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -27,12 +27,19 @@ export default defineConfig({
         text: 'Features',
         items: [
           { text: 'Authentication', link: '/guide/authentication' },
+          { text: 'Data Fetching', link: '/guide/data-fetching' },
           { text: 'Realtime & WebSockets', link: '/guide/realtime' },
           { text: 'File Management', link: '/guide/files' },
           { text: 'Visual Editor', link: '/guide/visual-editor' },
           { text: 'Type Generation', link: '/guide/type-generation' },
           { text: 'Proxy', link: '/guide/proxy' },
           { text: 'Server-Side Utils', link: '/guide/server-side' },
+        ],
+      },
+      {
+        text: 'Experimental',
+        items: [
+          { text: 'Data Loaders', link: '/guide/experimental-data-loaders' },
         ],
       },
       {

--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -378,6 +378,43 @@ Your `exclude` list is added to the module's built-in exclusions; you don't need
 
 Tree-shaking means disabling auto-imports has no bundle-size benefit for end users — unused SDK functions don't ship regardless. The option exists for collisions and for teams that prefer explicit imports.
 
+### Pinia Colada
+
+#### `piniaColada`
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Controls the [Pinia Colada integration](/guide/data-fetching#pinia-colada-queries). When `@pinia/colada` is installed in your project, the module auto-imports `useDirectusItemsQuery()`, `useDirectusItemQuery()` and `useDirectusSingletonQuery()` and registers `@pinia/nuxt` / `@pinia/colada-nuxt` if they are not already in your `modules`. Does nothing when the package is not installed.
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    // Disable even when @pinia/colada is installed
+    piniaColada: false,
+  },
+})
+```
+
+#### `experimental.dataLoaders`
+
+- **Type:** `boolean | { registerPlugin?: boolean }`
+- **Default:** `false`
+
+Opt-in to [vue-router data loaders](/guide/experimental-data-loaders) <Badge type="warning" text="experimental" />. Auto-imports `defineDirectusLoader()` and registers the vue-router `DataLoaderPlugin`. Requires the Pinia Colada packages.
+
+```typescript
+export default defineNuxtConfig({
+  directus: {
+    experimental: {
+      dataLoaders: true,
+    },
+  },
+})
+```
+
+Set `registerPlugin: false` if your app installs the `DataLoaderPlugin` itself.
+
 ### Authentication Options
 
 #### `auth`

--- a/docs/guide/data-fetching.md
+++ b/docs/guide/data-fetching.md
@@ -1,0 +1,122 @@
+# Data Fetching
+
+nuxt-directus-sdk ships typed data fetching composables on two levels:
+
+- **`useAsyncData` composables** (always available): `useDirectusItems()`, `useDirectusItem()` and `useDirectusSingleton()` wrap the Directus SDK in Nuxt's native `useAsyncData`, with SSR payload transfer and deterministic keys handled for you.
+- **Pinia Colada queries** (auto-enabled): with [`@pinia/colada`](https://pinia-colada.esm.dev) installed, the module adds cached query composables on top.
+
+All of them are fully typed against your generated `DirectusSchema`, including query `fields` narrowing.
+
+There is also an experimental third level, [vue-router data loaders](/guide/experimental-data-loaders), which fetch during navigation instead of component setup.
+
+## useAsyncData Composables
+
+These work out of the box with no extra dependencies.
+
+### `useDirectusItems()`
+
+Fetch a list of items from a collection:
+
+```vue
+<script setup lang="ts">
+const { data: posts, pending, error, refresh } = await useDirectusItems('posts', {
+  query: {
+    filter: { status: { _eq: 'published' } },
+    sort: ['-date_created'],
+    limit: 10,
+  },
+})
+</script>
+```
+
+### `useDirectusItem()`
+
+Fetch a single item by primary key:
+
+```vue
+<script setup lang="ts">
+const route = useRoute()
+
+const { data: post } = await useDirectusItem('posts', route.params.id as string, {
+  query: { fields: ['*', { author: ['name'] }] },
+})
+</script>
+```
+
+### `useDirectusSingleton()`
+
+Fetch a singleton collection (like site settings):
+
+```vue
+<script setup lang="ts">
+const { data: settings } = await useDirectusSingleton('settings')
+</script>
+```
+
+All three accept the standard `useAsyncData` options (`immediate`, `lazy`, `watch`, `server`, ...) plus an optional `key` to override the generated one. Keys default to `directus:{kind}:{collection}:{query}` so identical calls share one fetch.
+
+## Pinia Colada Queries
+
+[Pinia Colada](https://pinia-colada.esm.dev) is the data fetching layer for pinia. Where `useAsyncData` fetches per key/page, Colada gives you an app-wide normalized cache: every component calling the same key shares one entry, `staleTime` controls background refetches, and mutations can invalidate keys.
+
+### Setup
+
+Install the packages and the composables enable automatically:
+
+```bash
+pnpm add @pinia/colada @pinia/colada-nuxt @pinia/nuxt pinia
+```
+
+When `@pinia/colada` is detected, nuxt-directus-sdk:
+
+- registers `@pinia/nuxt` and `@pinia/colada-nuxt` (if not already in your `modules`)
+- auto-imports `useDirectusItemsQuery()`, `useDirectusItemQuery()` and `useDirectusSingletonQuery()`
+
+`@pinia/colada-nuxt` handles SSR hydration, so data fetched on the server is not refetched on the client. Set `piniaColada: false` in the module options to disable the integration even when the package is installed.
+
+### Query Composables
+
+The `*Query` composables mirror the `useAsyncData` ones, but go through the Colada cache:
+
+```vue
+<script setup lang="ts">
+// Shared by key across the whole app: calling this in a header and a
+// sidebar triggers a single request.
+const { data: navigation, isLoading } = useDirectusItemsQuery('pages', {
+  query: { filter: { show_in_nav: { _eq: true } } },
+  staleTime: 1000 * 60 * 5, // fresh for 5 minutes
+})
+</script>
+```
+
+Pass a ref or getter as the item id (or as `query`) and the entry key tracks it, refetching when it changes:
+
+```vue
+<script setup lang="ts">
+const route = useRoute()
+
+const { data: post, asyncStatus } = useDirectusItemQuery('posts', () => route.params.id as string)
+</script>
+```
+
+They accept all `useQuery` options (`staleTime`, `gcTime`, `enabled`, `refetchOnWindowFocus`, ...) plus an optional `key` override. Keys default to `['directus', kind, collection, ...]` so you can target them with `useQueryCache()` invalidation after a mutation:
+
+```ts
+const queryCache = useQueryCache()
+
+await directus.request(createItem('posts', newPost))
+queryCache.invalidateQueries({ key: ['directus', 'items', 'posts'] })
+```
+
+### Which One Should I Use?
+
+| | `useAsyncData` composables | Colada queries | [Data loaders](/guide/experimental-data-loaders) |
+| --- | --- | --- | --- |
+| Extra dependencies | none | `@pinia/colada` | `@pinia/colada` |
+| Stability | stable | stable | experimental |
+| Cache scope | per key, payload-based | app-wide, normalized | app-wide, normalized |
+| Background refetch | manual (`refresh`) | `staleTime` / `refetchOn*` | `staleTime` / `refetchOn*` |
+| Runs | component setup | component setup | during navigation |
+| Best for | simple pages, minimal deps | shared data (nav, settings, lists) | route-driven page data |
+
+If you are already using Pinia Colada (or fetch the same data in several components), prefer the Colada layer. Otherwise the `useAsyncData` composables are all you need. For route-driven page data where you want the fetch to happen during navigation, look at the experimental [data loaders](/guide/experimental-data-loaders).

--- a/docs/guide/experimental-data-loaders.md
+++ b/docs/guide/experimental-data-loaders.md
@@ -1,0 +1,107 @@
+# Data Loaders
+
+::: warning Experimental
+Data loaders build on vue-router's experimental data loader API (`vue-router/experimental`). The module isolates you from most of the surface through `defineDirectusLoader()`, but the underlying behaviour may change between vue-router releases, which is why this feature lives under `experimental` and is off by default. See the [vue-router data loaders docs](https://router.vuejs.org/data-loaders/) for details.
+:::
+
+Data loaders run during navigation, inside the router guard, so page data is ready on first paint: no `await` in setup blocking hydration, and no loading flash on client-side navigation. `defineDirectusLoader()` wraps vue-router's `defineColadaLoader()` and injects the Directus client, sharing the same [Pinia Colada cache](/guide/data-fetching#pinia-colada-queries) as the query composables.
+
+## Setup
+
+Data loaders require the [Pinia Colada packages](/guide/data-fetching#setup) and an explicit opt-in:
+
+```ts
+export default defineNuxtConfig({
+  directus: {
+    experimental: {
+      dataLoaders: true,
+    },
+  },
+})
+```
+
+If your app already registers the `DataLoaderPlugin` itself, keep your plugin and skip the module's:
+
+```ts
+export default defineNuxtConfig({
+  directus: {
+    experimental: {
+      dataLoaders: {
+        registerPlugin: false,
+      },
+    },
+  },
+})
+```
+
+When enabled, the module auto-imports `defineDirectusLoader()` and registers the vue-router `DataLoaderPlugin` for you.
+
+## Defining a Loader
+
+Define the loader in a non-setup `<script>` block and export it from the page component so the router picks it up:
+
+```vue
+<script lang="ts">
+export const usePostLoader = defineDirectusLoader({
+  key: to => ['posts', to.params.slug as string],
+  query: (directus, to) => directus.request(readItems('posts', {
+    filter: { slug: { _eq: to.params.slug as string } },
+    limit: 1,
+  })).then(posts => posts[0] ?? null),
+  staleTime: 1000 * 60 * 5,
+})
+</script>
+
+<script setup lang="ts">
+const { data: post, isLoading, refresh } = usePostLoader()
+</script>
+```
+
+The `query` function receives the Directus client, the target route, and the loader context (whose `signal` aborts when the navigation is cancelled). All `defineColadaLoader()` options are supported (`staleTime`, `lazy`, `server`, `commit`, ...).
+
+Loaders share the Colada cache with the query composables: a loader with key `['posts', slug]` and a `useQuery` with the same key deduplicate into one entry, one request, and one SSR hydration payload.
+
+## Guaranteed Data: Throw to Abort Navigation
+
+Because loaders run inside the navigation guard, throwing aborts the navigation before the page ever renders. That gives you a guarantee the `useAsyncData` and query composables cannot: if the component renders at all, `data` is exactly what the loader returned. No `v-if="post"` guards for the impossible states, no half-rendered pages when a record is missing.
+
+```ts
+export const usePageLoader = defineDirectusLoader({
+  key: to => ['pages', to.params.slug as string],
+  query: async (directus, to) => {
+    const pages = await directus.request(readItems('pages', {
+      filter: { slug: { _eq: to.params.slug as string } },
+      limit: 1,
+    }))
+
+    // Throwing aborts the navigation and renders the error page instead,
+    // so every component on this route can trust that `page` exists.
+    if (!pages[0]) {
+      throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+    }
+
+    return pages[0]
+  },
+})
+```
+
+You can validate shape as well as existence: parse the response with your own checks (or a schema library) and throw when the CMS content is not what the page requires, turning bad content into a navigation error instead of a rendering bug.
+
+To redirect instead of erroring, return a `NavigationResult`:
+
+```ts
+import { NavigationResult } from 'vue-router/experimental'
+
+export const useDraftGuardLoader = defineDirectusLoader({
+  key: to => ['posts', to.params.slug as string],
+  query: async (directus, to) => {
+    const post = await fetchPost(directus, to)
+
+    if (post?.status !== 'published') {
+      return new NavigationResult('/blog')
+    }
+
+    return post
+  },
+})
+```

--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
     "@directus/sdk": ">=21.0.0",
     "@directus/types": ">=15.0.0",
     "@directus/visual-editing": ">=2.0.0",
-    "@nuxt/image": ">=2.0.0"
+    "@nuxt/image": ">=2.0.0",
+    "@pinia/colada": ">=1.3.0",
+    "@pinia/colada-nuxt": ">=1.0.0",
+    "@pinia/nuxt": ">=0.11.0"
   },
   "peerDependenciesMeta": {
     "@directus/types": {
@@ -74,6 +77,15 @@
       "optional": true
     },
     "@nuxt/image": {
+      "optional": true
+    },
+    "@pinia/colada": {
+      "optional": true
+    },
+    "@pinia/colada-nuxt": {
+      "optional": true
+    },
+    "@pinia/nuxt": {
       "optional": true
     }
   },
@@ -93,10 +105,14 @@
     "@nuxt/module-builder": "^1.0.2",
     "@nuxt/schema": "^4.4.2",
     "@nuxt/test-utils": "^4.0.2",
+    "@pinia/colada": "^1.3.1",
+    "@pinia/colada-nuxt": "^1.0.1",
+    "@pinia/nuxt": "^0.11.3",
     "@types/http-proxy": "^1.17.17",
     "changelogen": "^0.6.1",
     "eslint": "^10.2.1",
     "nuxt": "^4.4.2",
+    "pinia": "^3.0.4",
     "typescript": "^6.0.3",
     "vitepress": "^1.6.4",
     "vitest": "^4.1.4",

--- a/playground/composables/useNav.ts
+++ b/playground/composables/useNav.ts
@@ -32,6 +32,7 @@ export function useNav(): NavGroup[] {
       links: [
         { label: 'Auto-Imports', to: '/data/auto-import', description: '<code>readSingleton()</code> vs. <code>useAsyncData()</code>' },
         { label: 'Blog (readItems)', to: '/blog', description: '<code>useDirectus()</code> + <code>readItems()</code> with filter &amp; sort' },
+        { label: 'Pinia Colada', to: '/data/colada', description: '<code>defineDirectusLoader()</code>, <code>useDirectusSingletonQuery()</code>' },
       ],
     },
     {

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -25,6 +25,9 @@ export default defineNuxtConfig({
     },
     devtools: true,
     visualEditor: true,
+    experimental: {
+      dataLoaders: {},
+    },
     types: {
       enabled: true,
       prefix: 'Rolley',

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,6 +13,10 @@
     "@nuxt/devtools": "latest",
     "@nuxt/image": "^2.0.0",
     "@nuxt/ui": "^4.0.0",
-    "nuxt": "latest"
+    "@pinia/colada": "^1.3.1",
+    "@pinia/colada-nuxt": "^1.0.1",
+    "@pinia/nuxt": "^0.11.3",
+    "nuxt": "latest",
+    "pinia": "^3.0.4"
   }
 }

--- a/playground/pages/data/colada.vue
+++ b/playground/pages/data/colada.vue
@@ -1,0 +1,97 @@
+<script lang="ts">
+import { defineDirectusLoader, readItems, useDirectusSingletonQuery } from '#imports'
+
+// Data loader: runs in the router's navigation guard, so the posts are ready
+// before the page renders. Export the loader from the page component so the
+// router picks it up.
+export const usePostsLoader = defineDirectusLoader({
+  key: ['playground', 'posts'],
+  query: directus => directus.request(readItems('posts', {
+    fields: ['id', 'title', 'slug'],
+    sort: ['-date_created'],
+    limit: 5,
+  })),
+  staleTime: 1000 * 60, // fresh for a minute; instant back/forward navigation
+})
+</script>
+
+<script setup lang="ts">
+const { data: posts, isLoading: postsLoading, refetch } = usePostsLoader()
+
+// Cached query composable: shared by key across every component that calls
+// it, so mounting this section twice still fires a single request.
+const { data: globals, asyncStatus } = useDirectusSingletonQuery('globals', {
+  staleTime: 1000 * 60 * 5,
+})
+</script>
+
+<template>
+  <div class="space-y-8">
+    <div>
+      <h1 class="text-3xl font-bold mb-2">
+        Pinia Colada
+      </h1>
+      <p class="text-muted">
+        With <code class="text-xs bg-elevated px-1 py-0.5 rounded">@pinia/colada</code> installed, the module adds cached query composables on top of the Directus SDK. Router data loaders are opt-in via <code class="text-xs bg-elevated px-1 py-0.5 rounded">experimental.dataLoaders</code>.
+      </p>
+    </div>
+
+    <section class="pt-6 border-t border-default">
+      <h2 class="text-base font-semibold mb-2">
+        Data loader: <code class="text-xs bg-elevated px-1 py-0.5 rounded">defineDirectusLoader()</code>
+      </h2>
+      <p class="text-sm text-muted mb-3">
+        Loaders run during navigation, so the data is ready on first paint with no <code class="text-xs bg-elevated px-1 py-0.5 rounded">await</code> in setup and no loading flash on client-side navigation.
+      </p>
+
+      <pre class="bg-elevated border border-default rounded p-4 text-xs overflow-x-auto mb-4">// &lt;script lang="ts"&gt; (non-setup block, exported from the page)
+export const usePostsLoader = defineDirectusLoader({
+  key: ['playground', 'posts'],
+  query: directus =&gt; directus.request(readItems('posts', { limit: 5 })),
+  staleTime: 1000 * 60,
+})
+
+// &lt;script setup lang="ts"&gt;
+const { data: posts, isLoading } = usePostsLoader()</pre>
+
+      <p class="text-sm font-semibold mb-1">
+        Live result:
+      </p>
+      <p
+        v-if="postsLoading"
+        class="text-sm text-muted"
+      >
+        Loading posts...
+      </p>
+      <pre
+        v-else
+        class="bg-elevated border border-default rounded p-4 text-xs overflow-x-auto mb-3"
+      >{{ JSON.stringify(posts, null, 2) }}</pre>
+      <UButton
+        size="xs"
+        variant="soft"
+        @click="refetch()"
+      >
+        Refetch posts
+      </UButton>
+    </section>
+
+    <section class="pt-6 border-t border-default">
+      <h2 class="text-base font-semibold mb-2">
+        Cached queries: <code class="text-xs bg-elevated px-1 py-0.5 rounded">useDirectusItemsQuery()</code> and friends
+      </h2>
+      <p class="text-sm text-muted mb-3">
+        <code class="text-xs bg-elevated px-1 py-0.5 rounded">useDirectusItemsQuery()</code>, <code class="text-xs bg-elevated px-1 py-0.5 rounded">useDirectusItemQuery()</code> and <code class="text-xs bg-elevated px-1 py-0.5 rounded">useDirectusSingletonQuery()</code> mirror the <code class="text-xs bg-elevated px-1 py-0.5 rounded">useAsyncData</code> composables but share one cache entry per key across the whole app, with <code class="text-xs bg-elevated px-1 py-0.5 rounded">staleTime</code> controlling refetches.
+      </p>
+
+      <pre class="bg-elevated border border-default rounded p-4 text-xs overflow-x-auto mb-4">const { data: globals, asyncStatus } = useDirectusSingletonQuery('globals', {
+  staleTime: 1000 * 60 * 5,
+})</pre>
+
+      <p class="text-sm font-semibold mb-1">
+        Live result (<code class="text-xs bg-elevated px-1 py-0.5 rounded">{{ asyncStatus }}</code>):
+      </p>
+      <pre class="bg-elevated border border-default rounded p-4 text-xs overflow-x-auto">{{ JSON.stringify(globals, null, 2) }}</pre>
+    </section>
+  </div>
+</template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,15 @@ importers:
       '@nuxt/test-utils':
         specifier: ^4.0.2
         version: 4.0.3(crossws@0.4.6(srvx@0.11.16))(magicast@0.5.3)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.8(@types/node@25.9.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))
+      '@pinia/colada':
+        specifier: ^1.3.1
+        version: 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+      '@pinia/colada-nuxt':
+        specifier: ^1.0.1
+        version: 1.0.1(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(magicast@0.5.3)
+      '@pinia/nuxt':
+        specifier: ^0.11.3
+        version: 0.11.3(magicast@0.5.3)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))
       '@types/http-proxy':
         specifier: ^1.17.17
         version: 1.17.17
@@ -59,7 +68,10 @@ importers:
         version: 10.4.1(jiti@2.7.0)
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -93,9 +105,21 @@ importers:
       '@nuxt/ui':
         specifier: ^4.0.0
         version: 4.8.2(@internationalized/date@3.12.2)(@internationalized/number@3.6.7)(@tiptap/extensions@3.26.1(@tiptap/core@3.26.1(@tiptap/pm@3.26.1))(@tiptap/pm@3.26.1))(@tiptap/y-tiptap@3.0.5(prosemirror-model@1.25.8)(prosemirror-state@1.4.4)(prosemirror-view@1.41.9)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31))(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(focus-trap@7.8.0)(ioredis@5.11.1)(magicast@0.5.3)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.1(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.24(typescript@6.0.3))(yjs@13.6.31)(zod@4.1.12)
+      '@pinia/colada':
+        specifier: ^1.3.1
+        version: 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3))
+      '@pinia/colada-nuxt':
+        specifier: ^1.0.1
+        version: 1.0.1(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(magicast@0.5.3)
+      '@pinia/nuxt':
+        specifier: ^0.11.3
+        version: 0.11.3(magicast@0.5.3)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))
       nuxt:
         specifier: latest
-        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+        version: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3))
 
 packages:
 
@@ -2311,6 +2335,22 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pinia/colada-nuxt@1.0.1':
+    resolution: {integrity: sha512-Jhyz4pTrBS8UMh9Bz43oKQEJalWx2hTc+27oWKJMpaIs/Yghj593WW+8NF3YPGCNiqYLIgyofwgL4DAExpkluw==}
+    peerDependencies:
+      '@pinia/colada': '>=1.3.0'
+
+  '@pinia/colada@1.3.1':
+    resolution: {integrity: sha512-DLHtyCud5sACbNLdVIHsoPrhcHMT/1LvObFHxxbmJKU2fqGPluc8Y8CtmCTQ71BgnzcNMuAl97G5XrAgOZqxvg==}
+    peerDependencies:
+      pinia: ^2.2.6 || ^3.0.0
+      vue: ^3.5.17
+
+  '@pinia/nuxt@0.11.3':
+    resolution: {integrity: sha512-7WVNHpWx4qAEzOlnyrRC88kYrwnlR/PrThWT0XI1dSNyUAXu/KBv9oR37uCgYkZroqP5jn8DfzbkNF3BtKvE9w==}
+    peerDependencies:
+      pinia: ^3.0.4
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5546,6 +5586,15 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pinia@3.0.4:
+    resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+      vue: ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -8801,7 +8850,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.133.0)(srvx@0.11.16)(typescript@6.0.3)':
+  '@nuxt/nitro-server@4.4.8(5c99213365bdd0f50cfaeb082764fce3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
@@ -8819,7 +8868,77 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.4(oxc-parser@0.133.0)(srvx@0.11.16)
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      nypm: 0.6.7
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.8.1
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unctx: 2.5.0
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      vue: 3.5.38(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - srvx
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
+  '@nuxt/nitro-server@4.4.8(6080c75cc8233756b9809aeefaff4d4b)':
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@unhead/vue': 2.1.15(vue@3.5.38(typescript@6.0.3))
+      '@vue/shared': 3.5.38
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.11
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(oxc-parser@0.133.0)(srvx@0.11.16)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.7
       ohash: 2.0.11
       pathe: 2.0.3
@@ -9040,7 +9159,7 @@ snapshots:
       - vue
       - yjs
 
-  '@nuxt/vite-builder@4.4.8(a7685259601f77da4964c41a77ef08cf)':
+  '@nuxt/vite-builder@4.4.8(4056e61a0c6aeb14900132f648ae8832)':
     dependencies:
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
       '@rollup/plugin-replace': 6.0.3(rollup@4.61.1)
@@ -9058,7 +9177,65 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      nypm: 0.6.7
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      postcss: 8.5.15
+      seroval: 1.5.4
+      std-env: 4.1.0
+      ufo: 1.6.4
+      unenv: 2.0.0-rc.24
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
+      vite-plugin-checker: 0.14.1(eslint@10.4.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))
+      vue: 3.5.38(typescript@6.0.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
+      rollup-plugin-visualizer: 7.0.1(rollup@4.61.1)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vue-tsc
+      - yaml
+
+  '@nuxt/vite-builder@4.4.8(941816b7a11c4d49649f883e412c9289)':
+    dependencies:
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.61.1)
+      '@vitejs/plugin-vue': 6.0.7(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      autoprefixer: 10.5.0(postcss@8.5.15)
+      consola: 3.4.2
+      cssnano: 8.0.2(postcss@8.5.15)
+      defu: 6.1.7
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.7.0
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
       nypm: 0.6.7
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9433,6 +9610,44 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
+
+  '@pinia/colada-nuxt@1.0.1(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(magicast@0.5.3)':
+    dependencies:
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@pinia/colada': 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3))
+    transitivePeerDependencies:
+      - magicast
+
+  '@pinia/colada-nuxt@1.0.1(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(magicast@0.5.3)':
+    dependencies:
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@pinia/colada': 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+    transitivePeerDependencies:
+      - magicast
+
+  '@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3))':
+    dependencies:
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3))
+      vue: 3.5.24(typescript@6.0.3)
+
+  '@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))':
+    dependencies:
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
+      vue: 3.5.38(typescript@6.0.3)
+
+  '@pinia/nuxt@0.11.3(magicast@0.5.3)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))':
+    dependencies:
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3))
+    transitivePeerDependencies:
+      - magicast
+
+  '@pinia/nuxt@0.11.3(magicast@0.5.3)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))':
+    dependencies:
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
+    transitivePeerDependencies:
+      - magicast
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -12791,16 +13006,16 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0):
+  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
       '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3)
       '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@nuxt/kit': 4.4.8(magicast@0.5.3)
-      '@nuxt/nitro-server': 4.4.8(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0))(oxc-parser@0.133.0)(srvx@0.11.16)(typescript@6.0.3)
+      '@nuxt/nitro-server': 4.4.8(6080c75cc8233756b9809aeefaff4d4b)
       '@nuxt/schema': 4.4.8
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.8(magicast@0.5.3))
-      '@nuxt/vite-builder': 4.4.8(a7685259601f77da4964c41a77ef08cf)
+      '@nuxt/vite-builder': 4.4.8(4056e61a0c6aeb14900132f648ae8832)
       '@unhead/vue': 2.1.15(vue@3.5.38(typescript@6.0.3))
       '@vue/shared': 3.5.38
       chokidar: 5.0.0
@@ -12848,7 +13063,136 @@ snapshots:
       unrouting: 0.1.7
       untyped: 2.0.0
       vue: 3.5.38(typescript@6.0.3)
-      vue-router: 5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      vue-router: 5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 25.9.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@babel/plugin-syntax-typescript'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vue-tsc
+      - xml2js
+      - yaml
+
+  nuxt@4.4.8(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@parcel/watcher@2.5.6)(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(@types/node@25.9.3)(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(@vue/compiler-sfc@3.5.38)(cac@6.7.14)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.61.1))(rollup@4.61.1)(srvx@0.11.16)(terser@5.48.0)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0):
+    dependencies:
+      '@dxup/nuxt': 0.4.1(magicast@0.5.3)(typescript@6.0.3)
+      '@nuxt/cli': 3.35.2(@nuxt/schema@4.4.8)(cac@6.7.14)(magicast@0.5.3)
+      '@nuxt/devtools': 3.2.4(@vitejs/devtools@0.3.3(crossws@0.4.6(srvx@0.11.16))(db0@0.3.4)(ioredis@5.11.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/nitro-server': 4.4.8(5c99213365bdd0f50cfaeb082764fce3)
+      '@nuxt/schema': 4.4.8
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.8(magicast@0.5.3))
+      '@nuxt/vite-builder': 4.4.8(941816b7a11c4d49649f883e412c9289)
+      '@unhead/vue': 2.1.15(vue@3.5.38(typescript@6.0.3))
+      '@vue/shared': 3.5.38
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 3.1.1
+      defu: 6.1.7
+      devalue: 5.8.1
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.1
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.7
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.133.0
+      oxc-parser: 0.133.0
+      oxc-transform: 0.133.0
+      oxc-walker: 1.0.0(oxc-parser@0.133.0)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.4
+      pkg-types: 2.3.1
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.8.4
+      std-env: 4.1.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unhead: 2.1.15
+      unimport: 6.3.0(oxc-parser@0.133.0)
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.38(typescript@6.0.3)
+      vue-router: 5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.6
       '@types/node': 25.9.3
@@ -13146,6 +13490,20 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)):
+    dependencies:
+      '@vue/devtools-api': 7.7.9
+      vue: 3.5.24(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)):
+    dependencies:
+      '@vue/devtools-api': 7.7.9
+      vue: 3.5.38(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
 
   pkg-types@1.3.1:
     dependencies:
@@ -14672,7 +15030,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+  vue-router@5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3)))(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
       '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@6.0.3))
@@ -14693,7 +15051,35 @@ snapshots:
       vue: 3.5.38(typescript@6.0.3)
       yaml: 2.9.0
     optionalDependencies:
+      '@pinia/colada': 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3)))(vue@3.5.24(typescript@6.0.3))
       '@vue/compiler-sfc': 3.5.38
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.24(typescript@6.0.3))
+      vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
+
+  vue-router@5.1.0(@pinia/colada@1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3)))(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+    dependencies:
+      '@babel/generator': 8.0.0-rc.6
+      '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@6.0.3))
+      '@vue/devtools-api': 8.1.2
+      ast-walker-scope: 0.9.0
+      chokidar: 5.0.0
+      json5: 2.2.3
+      local-pkg: 1.2.1
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      muggle-string: 0.4.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      unplugin: 3.0.0
+      unplugin-utils: 0.3.1
+      vue: 3.5.38(typescript@6.0.3)
+      yaml: 2.9.0
+    optionalDependencies:
+      '@pinia/colada': 1.3.1(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+      '@vue/compiler-sfc': 3.5.38
+      pinia: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
 
   vue-sfc-transformer@0.1.17(@vue/compiler-core@3.5.38)(esbuild@0.28.0)(vue@3.5.38(typescript@6.0.3)):

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import type { ImageModifiers, ImageProviders } from '@nuxt/image'
 import type { InlinePreset } from 'unimport'
 
 import * as directusSdk from '@directus/sdk'
-import { addComponentsDir, addImportsDir, addImportsSources, addPlugin, addRouteMiddleware, addServerHandler, addTypeTemplate, createResolver, defineNuxtModule, hasNuxtModule, installModule, tryResolveModule, useLogger } from '@nuxt/kit'
+import { addComponentsDir, addImports, addImportsDir, addImportsSources, addPlugin, addRouteMiddleware, addServerHandler, addTypeTemplate, createResolver, defineNuxtModule, hasNuxtModule, installModule, tryResolveModule, useLogger } from '@nuxt/kit'
 import { colors } from 'consola/utils'
 import { defu } from 'defu'
 import { joinURL } from 'ufo'
@@ -237,6 +237,50 @@ export interface ModuleOptions {
   }
 
   /**
+   * Pinia Colada integration. When `@pinia/colada` is installed in your
+   * project, the module auto-imports cached query composables
+   * (`useDirectusItemsQuery`, `useDirectusItemQuery`,
+   * `useDirectusSingletonQuery`) backed by the Colada query cache, and
+   * registers `@pinia/nuxt` / `@pinia/colada-nuxt` if they are not already
+   * in your modules. Set to `false` to disable even when installed.
+   *
+   * Router data loaders are separate and opt-in: see
+   * `experimental.dataLoaders`.
+   *
+   * @default true
+   */
+  piniaColada?: boolean
+
+  /**
+   * Experimental features. Everything in here builds on upstream APIs that
+   * may change between releases, so each feature is off by default and must
+   * be enabled explicitly.
+   */
+  experimental?: {
+    /**
+     * vue-router data loaders: auto-imports the `defineDirectusLoader()`
+     * factory and registers the `DataLoaderPlugin`. Loaders run during
+     * navigation so page data is ready on first paint.
+     *
+     * Requires `@pinia/colada` (see `piniaColada`) and vue-router with the
+     * `experimental` exports. Experimental because vue-router's data loader
+     * API is itself experimental.
+     *
+     * `true` or an options object enables it.
+     *
+     * @default false
+     */
+    dataLoaders?: boolean | {
+      /**
+       * Register the vue-router `DataLoaderPlugin`. Disable if your app
+       * installs the plugin itself.
+       * @default true
+       */
+      registerPlugin?: boolean
+    }
+  }
+
+  /**
    * Auto-import functions from `@directus/sdk`.
    *
    * - `true` (default) — auto-imports every SDK function except those wrapped by
@@ -283,6 +327,10 @@ export default defineNuxtModule<ModuleOptions>({
       prefix: '',
     },
     autoImportSdk: true,
+    piniaColada: true,
+    experimental: {
+      dataLoaders: false,
+    },
     auth: {
       enabled: true,
       enableGlobalAuthMiddleware: false,
@@ -554,6 +602,82 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Add composables
     addImportsDir(resolver.resolve('./runtime/composables'))
+
+    // Pinia Colada integration: cached query composables, auto-enabled when
+    // @pinia/colada is installed (opt out with piniaColada: false). Router
+    // data loaders build on vue-router's experimental API and are opt-in
+    // via experimental.dataLoaders.
+    const coladaWanted = options.piniaColada !== false
+    const modulesDir = nuxtApp.options.modulesDir
+    const coladaEntry = coladaWanted ? await tryResolveModule('@pinia/colada', modulesDir) : undefined
+
+    const dataLoadersOption = options.experimental?.dataLoaders ?? false
+    const dataLoadersConfig = typeof dataLoadersOption === 'boolean' ? { enabled: dataLoadersOption } : { enabled: true, ...dataLoadersOption }
+
+    if (dataLoadersConfig.enabled && !coladaEntry) {
+      loggerMessage.push(
+        `🍹 ${colors.yellow('experimental.dataLoaders is enabled but Pinia Colada is unavailable')}`,
+        coladaWanted
+          ? `  - Install @pinia/colada (plus @pinia/colada-nuxt, @pinia/nuxt and pinia) to use data loaders`
+          : `  - Remove piniaColada: false to use data loaders`,
+        '',
+      )
+    }
+
+    if (coladaEntry) {
+      const hasPiniaNuxt = hasNuxtModule('@pinia/nuxt') || !!(await tryResolveModule('@pinia/nuxt', modulesDir))
+
+      if (!hasPiniaNuxt) {
+        loggerMessage.push(`🍹 ${colors.yellow('@pinia/colada found but @pinia/nuxt is missing')}`, `  - Install @pinia/nuxt to enable the Directus query composables`, '')
+      }
+      else {
+        await registerModule('@pinia/nuxt', 'pinia', {})
+
+        // Pin a single @pinia/colada instance. The module's runtime imports
+        // it as a peer, which in workspace/layer setups can resolve to a
+        // second copy next to the module instead of the app's copy that the
+        // PiniaColada plugin installed (two copies = "no active Pinia"
+        // errors from the query cache). The alias applies to Vite and Nitro,
+        // including externalized SSR resolution in dev.
+        nuxtApp.options.alias['@pinia/colada'] = coladaEntry
+
+        if (hasNuxtModule('@pinia/colada-nuxt') || await tryResolveModule('@pinia/colada-nuxt', modulesDir)) {
+          await registerModule('@pinia/colada-nuxt', 'colada', {})
+        }
+        else {
+          loggerMessage.push(`  - ${colors.yellow('Install @pinia/colada-nuxt for SSR cache hydration')} (queries will refetch on the client without it)`)
+        }
+
+        addImports(['useDirectusItemsQuery', 'useDirectusItemQuery', 'useDirectusSingletonQuery'].map(name => ({
+          name,
+          from: resolver.resolve('./runtime/colada/queries'),
+        })))
+        loggerMessage.push('🍹 Pinia Colada detected: useDirectusItemsQuery, useDirectusItemQuery and useDirectusSingletonQuery added')
+
+        // Data loaders need the experimental vue-router exports (Nuxt >= 4.2)
+        // and the pages router to exist.
+        const pagesOption = nuxtApp.options.pages as boolean | { enabled?: boolean } | undefined
+        const pagesEnabled = typeof pagesOption === 'object' ? pagesOption?.enabled !== false : pagesOption !== false
+        const hasExperimentalRouter = !!(await tryResolveModule('vue-router/experimental/pinia-colada', modulesDir))
+
+        if (dataLoadersConfig.enabled && pagesEnabled && hasExperimentalRouter) {
+          if (dataLoadersConfig.registerPlugin ?? true) {
+            addPlugin(resolver.resolve('./runtime/colada/data-loaders'))
+          }
+          addImports([{
+            name: 'defineDirectusLoader',
+            from: resolver.resolve('./runtime/colada/loaders'),
+          }])
+          loggerMessage.push('  - Experimental data loaders enabled: defineDirectusLoader added', '')
+        }
+        else if (dataLoadersConfig.enabled && !hasExperimentalRouter) {
+          loggerMessage.push(`  - ${colors.yellow('Data loaders skipped: vue-router experimental exports not found')} (upgrade Nuxt for defineDirectusLoader)`, '')
+        }
+        else {
+          loggerMessage.push('')
+        }
+      }
+    }
 
     // autoImportSdk=false disables auto-imports entirely; the { exclude }
     // shape adds user-provided names on top of the built-in exclusions.

--- a/src/runtime/colada/context.ts
+++ b/src/runtime/colada/context.ts
@@ -1,0 +1,10 @@
+import type { NuxtApp } from 'nuxt/app'
+import type { InjectionKey } from 'vue'
+
+// Data loaders run in the router's navigation guard, where no component
+// instance or unctx async context exists, so tryUseNuxtApp() comes back
+// empty on the server. The loader guard does wrap execution in Vue's
+// app.runWithContext(), which makes app-level inject() work; the
+// data-loaders plugin provides the Nuxt app under this key so loaders can
+// restore the Nuxt context from it.
+export const dataLoaderNuxtApp: InjectionKey<NuxtApp> = Symbol('directus-data-loader-nuxt-app')

--- a/src/runtime/colada/data-loaders.ts
+++ b/src/runtime/colada/data-loaders.ts
@@ -1,0 +1,30 @@
+import type { DataLoaderPluginOptions } from 'vue-router/experimental'
+import { defineNuxtPlugin } from '#imports'
+import { DataLoaderPlugin } from 'vue-router/experimental'
+import { dataLoaderNuxtApp } from './context'
+
+// Enables vue-router data loaders (defineDirectusLoader / defineColadaLoader).
+// Loaders run inside the navigation guard, so page data is ready on first
+// paint. Vue deduplicates repeated app.use() of the same plugin, so an app
+// that already installs DataLoaderPlugin itself is unaffected (a dev-mode
+// warning aside); set `experimental.dataLoaders.registerPlugin: false` to
+// skip this.
+export default defineNuxtPlugin({
+  name: 'directus:data-loaders',
+  dependsOn: ['nuxt:router'],
+  setup(nuxtApp) {
+    const router = nuxtApp.vueApp.config.globalProperties.$router
+
+    if (!router) {
+      return
+    }
+
+    // Loaders resolve the Nuxt app through app-level injection; see context.ts.
+    nuxtApp.vueApp.provide(dataLoaderNuxtApp, nuxtApp as never)
+
+    nuxtApp.vueApp.use(DataLoaderPlugin, {
+      router,
+      isSSR: import.meta.server,
+    } satisfies DataLoaderPluginOptions)
+  },
+})

--- a/src/runtime/colada/loaders.ts
+++ b/src/runtime/colada/loaders.ts
@@ -1,0 +1,86 @@
+import type { RouteLocationNormalizedLoaded, RouteMap } from 'vue-router'
+import type {
+  DataColadaLoaderContext,
+  DefineDataColadaLoaderOptions_LaxData,
+  UseDataLoaderColada_LaxData,
+} from 'vue-router/experimental/pinia-colada'
+import { tryUseNuxtApp } from '#imports'
+import { hasInjectionContext, inject } from 'vue'
+import { defineColadaLoader } from 'vue-router/experimental/pinia-colada'
+import { useDirectus } from '../composables/directus'
+import { dataLoaderNuxtApp } from './context'
+
+export type DirectusClient = ReturnType<typeof useDirectus>
+
+export interface DefineDirectusLoaderOptions<Name extends keyof RouteMap, Data>
+  extends Omit<DefineDataColadaLoaderOptions_LaxData<Name, Data>, 'query'> {
+  /**
+   * Fetches the data for the loader. Receives the Directus client, the target
+   * route, and the loader context (`signal` aborts on cancelled navigations).
+   */
+  query: (
+    directus: DirectusClient,
+    to: RouteLocationNormalizedLoaded<Name>,
+    context: DataColadaLoaderContext,
+  ) => Promise<Data>
+}
+
+/**
+ * Defines a vue-router data loader backed by the Pinia Colada cache with the
+ * Directus client injected into the query.
+ *
+ * Data loaders run during navigation (inside the router guard), so the data
+ * is ready on first paint with no `await` in setup. Export the loader from
+ * the page component that uses it so the router picks it up.
+ *
+ * @example
+ * ```vue
+ * <script lang="ts">
+ * export const usePostLoader = defineDirectusLoader({
+ *   key: to => ['posts', to.params.slug as string],
+ *   query: (directus, to) => directus.request(readItems('posts', {
+ *     filter: { slug: { _eq: to.params.slug as string } },
+ *     limit: 1,
+ *   })).then(posts => posts[0] ?? null),
+ *   staleTime: 1000 * 60 * 5,
+ * })
+ * </script>
+ *
+ * <script setup lang="ts">
+ * const { data: post, isLoading } = usePostLoader()
+ * </script>
+ * ```
+ */
+export function defineDirectusLoader<Name extends keyof RouteMap, Data>(
+  name: Name,
+  options: DefineDirectusLoaderOptions<Name, Data>,
+): UseDataLoaderColada_LaxData<Data>
+export function defineDirectusLoader<Data>(
+  options: DefineDirectusLoaderOptions<keyof RouteMap, Data>,
+): UseDataLoaderColada_LaxData<Data>
+export function defineDirectusLoader(
+  nameOrOptions: keyof RouteMap | DefineDirectusLoaderOptions<keyof RouteMap, unknown>,
+  maybeOptions?: DefineDirectusLoaderOptions<keyof RouteMap, unknown>,
+): UseDataLoaderColada_LaxData<unknown> {
+  const name = typeof nameOrOptions === 'string' ? nameOrOptions : undefined
+  const { query, ...loaderOptions } = (name ? maybeOptions : nameOrOptions) as DefineDirectusLoaderOptions<keyof RouteMap, unknown>
+
+  const wrapped = {
+    ...loaderOptions,
+    query: (to: RouteLocationNormalizedLoaded, context: DataColadaLoaderContext) => {
+      // Loaders run in the router's navigation guard, outside component
+      // setup, where tryUseNuxtApp() finds nothing on the server. The guard
+      // wraps loaders in app.runWithContext(), so app-level inject() reaches
+      // the Nuxt app provided by the data-loaders plugin. Restore the Nuxt
+      // context from it so useDirectus() (runtime config, SSR cookie
+      // forwarding) works inside the query.
+      const nuxtApp = tryUseNuxtApp() ?? (hasInjectionContext() ? inject(dataLoaderNuxtApp, null) : null)
+      const run = () => query(useDirectus(), to, context)
+      return nuxtApp ? nuxtApp.runWithContext(run) : run()
+    },
+  }
+
+  return name
+    ? defineColadaLoader(name, wrapped as never)
+    : defineColadaLoader(wrapped as never)
+}

--- a/src/runtime/colada/queries.ts
+++ b/src/runtime/colada/queries.ts
@@ -1,0 +1,134 @@
+import type {
+  Query,
+  QueryItem,
+  RegularCollections,
+  SingletonCollections,
+  UnpackList,
+} from '@directus/sdk'
+import type { EntryKey, UseQueryOptions, UseQueryReturn } from '@pinia/colada'
+import type { MaybeRefOrGetter } from 'vue'
+import { readItem, readItems, readSingleton } from '@directus/sdk'
+import { useQuery } from '@pinia/colada'
+import { toValue } from 'vue'
+import { useDirectus } from '../composables/directus'
+
+type RegularCollectionName = RegularCollections<DirectusSchema>
+type SingletonCollectionName = SingletonCollections<DirectusSchema>
+type CollectionItem<C extends keyof DirectusSchema> = UnpackList<DirectusSchema[C]>
+type DirectusUseQueryOptions<T> = Omit<UseQueryOptions<T>, 'key' | 'query'>
+
+// Directus query objects are plain JSON, so they can be embedded in the
+// Colada entry key directly. `?? null` keeps "no query" a stable key segment.
+function toKeySegment(query: unknown): EntryKey[number] {
+  return (query ?? null) as EntryKey[number]
+}
+
+export interface UseDirectusItemsQueryOptions<C extends RegularCollectionName, T>
+  extends DirectusUseQueryOptions<T> {
+  /** Explicit Colada entry key. Defaults to `['directus', 'items', collection, query]`. */
+  key?: MaybeRefOrGetter<EntryKey>
+  query?: MaybeRefOrGetter<Query<DirectusSchema, CollectionItem<C>>>
+}
+
+/**
+ * Fetch a list of items through the Pinia Colada cache.
+ *
+ * Unlike `useDirectusItems` (which uses `useAsyncData`), the result is cached
+ * and shared by key across every component that calls it, and refetched
+ * according to `staleTime`/`refetchOn*` options.
+ *
+ * @example
+ * ```ts
+ * const { data: posts, isLoading } = useDirectusItemsQuery('posts', {
+ *   query: { filter: { status: { _eq: 'published' } }, sort: ['-date_created'] },
+ *   staleTime: 1000 * 60 * 5,
+ * })
+ * ```
+ */
+export function useDirectusItemsQuery<
+  C extends RegularCollectionName,
+  T = CollectionItem<C>[],
+>(
+  collection: C,
+  options: UseDirectusItemsQueryOptions<C, T> = {},
+): UseQueryReturn<T> {
+  const { key, query, ...queryOptions } = options
+  const directus = useDirectus()
+
+  return useQuery({
+    key: key ?? (() => ['directus', 'items', collection, toKeySegment(toValue(query))]),
+    query: async () => await directus.request(readItems(collection, toValue(query) as never)) as T,
+    ...queryOptions,
+  } as UseQueryOptions<T>)
+}
+
+export interface UseDirectusItemQueryOptions<C extends RegularCollectionName, T>
+  extends DirectusUseQueryOptions<T> {
+  key?: MaybeRefOrGetter<EntryKey>
+  query?: MaybeRefOrGetter<QueryItem<DirectusSchema, CollectionItem<C>>>
+}
+
+/**
+ * Fetch a single item by primary key through the Pinia Colada cache.
+ *
+ * Pass a ref/getter as `id` (e.g. `() => route.params.id`) to refetch when it
+ * changes: the id is part of the entry key.
+ *
+ * @example
+ * ```ts
+ * const route = useRoute()
+ * const { data: post } = useDirectusItemQuery('posts', () => route.params.id as string, {
+ *   query: { fields: ['*', { author: ['name'] }] },
+ * })
+ * ```
+ */
+export function useDirectusItemQuery<
+  C extends RegularCollectionName,
+  T = CollectionItem<C>,
+>(
+  collection: C,
+  id: MaybeRefOrGetter<string | number>,
+  options: UseDirectusItemQueryOptions<C, T> = {},
+): UseQueryReturn<T> {
+  const { key, query, ...queryOptions } = options
+  const directus = useDirectus()
+
+  return useQuery({
+    key: key ?? (() => ['directus', 'item', collection, toValue(id), toKeySegment(toValue(query))]),
+    query: async () => await directus.request(readItem(collection, toValue(id), toValue(query) as never)) as T,
+    ...queryOptions,
+  } as UseQueryOptions<T>)
+}
+
+export interface UseDirectusSingletonQueryOptions<C extends SingletonCollectionName, T>
+  extends DirectusUseQueryOptions<T> {
+  key?: MaybeRefOrGetter<EntryKey>
+  query?: MaybeRefOrGetter<QueryItem<DirectusSchema, CollectionItem<C>>>
+}
+
+/**
+ * Fetch a singleton collection (e.g. settings) through the Pinia Colada cache.
+ *
+ * @example
+ * ```ts
+ * const { data: settings } = useDirectusSingletonQuery('settings', {
+ *   staleTime: 1000 * 60 * 10,
+ * })
+ * ```
+ */
+export function useDirectusSingletonQuery<
+  C extends SingletonCollectionName,
+  T = CollectionItem<C>,
+>(
+  collection: C,
+  options: UseDirectusSingletonQueryOptions<C, T> = {},
+): UseQueryReturn<T> {
+  const { key, query, ...queryOptions } = options
+  const directus = useDirectus()
+
+  return useQuery({
+    key: key ?? (() => ['directus', 'singleton', collection, toKeySegment(toValue(query))]),
+    query: async () => await directus.request(readSingleton(collection, toValue(query) as never)) as T,
+    ...queryOptions,
+  } as UseQueryOptions<T>)
+}

--- a/src/runtime/composables/items.ts
+++ b/src/runtime/composables/items.ts
@@ -1,0 +1,118 @@
+import type { AsyncData, AsyncDataOptions, NuxtError } from 'nuxt/app'
+import type {
+  Query,
+  QueryItem,
+  RegularCollections,
+  SingletonCollections,
+  UnpackList,
+} from '@directus/sdk'
+import { readItem, readItems, readSingleton } from '@directus/sdk'
+import { useAsyncData } from '#imports'
+import { useDirectus } from './directus'
+
+type RegularCollectionName = RegularCollections<DirectusSchema>
+type SingletonCollectionName = SingletonCollections<DirectusSchema>
+type CollectionItem<C extends keyof DirectusSchema> = UnpackList<DirectusSchema[C]>
+type DirectusAsyncData<T> = AsyncData<T | undefined, NuxtError | undefined>
+type DirectusAsyncDataOptions<T> = Omit<AsyncDataOptions<T>, 'default' | 'pick' | 'transform'>
+
+export interface UseDirectusItemsOptions<C extends RegularCollectionName, T>
+  extends DirectusAsyncDataOptions<T> {
+  /** Explicit useAsyncData key. Defaults to `directus:{collection}:{hash}`. */
+  key?: string
+  query?: Query<DirectusSchema, CollectionItem<C>>
+}
+
+function buildKey(parts: unknown[]): string {
+  return `directus:${parts.map(p => typeof p === 'string' ? p : JSON.stringify(p ?? null)).join(':')}`
+}
+
+/**
+ * Fetch a list of items with useAsyncData + full schema typing.
+ *
+ * @example
+ * ```ts
+ * const { data: posts } = await useDirectusItems('posts', {
+ *   query: { filter: { status: { _eq: 'published' } }, sort: ['-date_created'] },
+ * })
+ * ```
+ */
+export function useDirectusItems<
+  C extends RegularCollectionName,
+  T = CollectionItem<C>[],
+>(
+  collection: C,
+  options: UseDirectusItemsOptions<C, T> = {},
+): DirectusAsyncData<T> {
+  const { key, query, ...asyncOptions } = options
+  const dataKey = key ?? buildKey(['items', collection, query])
+  const directus = useDirectus()
+
+  return useAsyncData(
+    dataKey,
+    async () => await directus.request(readItems(collection, query as never)) as T,
+    asyncOptions as AsyncDataOptions<T>,
+  ) as unknown as DirectusAsyncData<T>
+}
+
+export interface UseDirectusItemOptions<C extends RegularCollectionName, T>
+  extends DirectusAsyncDataOptions<T> {
+  key?: string
+  query?: QueryItem<DirectusSchema, CollectionItem<C>>
+}
+
+/**
+ * Fetch a single item by primary key.
+ *
+ * @example
+ * ```ts
+ * const { data: post } = await useDirectusItem('posts', id, {
+ *   query: { fields: ['*', { author: ['name'] }] },
+ * })
+ * ```
+ */
+export function useDirectusItem<
+  C extends RegularCollectionName,
+  T = CollectionItem<C>,
+>(
+  collection: C,
+  id: string | number,
+  options: UseDirectusItemOptions<C, T> = {},
+): DirectusAsyncData<T> {
+  const { key, query, ...asyncOptions } = options
+  const dataKey = key ?? buildKey(['item', collection, id, query])
+  const directus = useDirectus()
+
+  return useAsyncData(
+    dataKey,
+    async () => await directus.request(readItem(collection, id, query as never)) as T,
+    asyncOptions as AsyncDataOptions<T>,
+  ) as unknown as DirectusAsyncData<T>
+}
+
+export interface UseDirectusSingletonOptions<C extends SingletonCollectionName, T>
+  extends DirectusAsyncDataOptions<T> {
+  key?: string
+  query?: QueryItem<DirectusSchema, CollectionItem<C>>
+}
+
+/**
+ * Fetch a singleton collection (e.g. settings).
+ */
+export function useDirectusSingleton<
+  C extends SingletonCollectionName,
+  T = CollectionItem<C>,
+>(
+  collection: C,
+  options: UseDirectusSingletonOptions<C, T> = {},
+): DirectusAsyncData<T> {
+  const { key, query, ...asyncOptions } = options
+  const dataKey = key ?? buildKey(['singleton', collection, query])
+  const directus = useDirectus()
+
+  return useAsyncData(
+    dataKey,
+    async () => await directus.request(readSingleton(collection, query as never)) as T,
+    asyncOptions as AsyncDataOptions<T>,
+  ) as unknown as DirectusAsyncData<T>
+}

--- a/test/colada-loaders.test.ts
+++ b/test/colada-loaders.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  defineColadaLoader: vi.fn((...args: unknown[]) => ({ args, type: 'loader' })),
+  nuxtApp: undefined as { runWithContext: ReturnType<typeof vi.fn> } | undefined,
+  request: vi.fn(),
+}))
+
+vi.mock('vue-router/experimental/pinia-colada', () => ({
+  defineColadaLoader: mocks.defineColadaLoader,
+}))
+
+vi.mock('#imports', () => ({
+  tryUseNuxtApp: vi.fn(() => mocks.nuxtApp),
+}))
+
+vi.mock('../src/runtime/composables/directus', () => ({
+  useDirectus: vi.fn(() => ({ request: mocks.request })),
+}))
+
+function passedOptions(): Record<string, unknown> {
+  const args = mocks.defineColadaLoader.mock.calls.at(-1)
+  return (typeof args?.[0] === 'string' ? args[1] : args?.[0]) as Record<string, unknown>
+}
+
+describe('defineDirectusLoader', () => {
+  beforeEach(() => {
+    mocks.defineColadaLoader.mockClear()
+    mocks.nuxtApp = undefined
+    mocks.request.mockReset()
+  })
+
+  it('forwards options to defineColadaLoader with a wrapped query', async () => {
+    const { defineDirectusLoader } = await import('../src/runtime/colada/loaders')
+
+    defineDirectusLoader({
+      key: ['posts'],
+      staleTime: 5_000,
+      query: (directus: { request: (q: unknown) => Promise<unknown> }) => directus.request('q'),
+    } as never)
+
+    const options = passedOptions()
+    expect(options.key).toEqual(['posts'])
+    expect(options.staleTime).toBe(5_000)
+    expect(options.query).toBeTypeOf('function')
+  })
+
+  it('supports the named-route overload', async () => {
+    const { defineDirectusLoader } = await import('../src/runtime/colada/loaders')
+
+    defineDirectusLoader('slug' as never, {
+      key: ['pages'],
+      query: async () => null,
+    } as never)
+
+    expect(mocks.defineColadaLoader.mock.calls.at(-1)?.[0]).toBe('slug')
+    expect(passedOptions().key).toEqual(['pages'])
+  })
+
+  it('injects the directus client and route into the query', async () => {
+    mocks.request.mockResolvedValueOnce([{ id: 1 }])
+    const { defineDirectusLoader } = await import('../src/runtime/colada/loaders')
+
+    const query = vi.fn((directus: { request: (q: unknown) => Promise<unknown> }) => directus.request('read'))
+    defineDirectusLoader({ key: ['posts'], query } as never)
+
+    const to = { params: { slug: 'home' } }
+    const context = { signal: undefined }
+    const wrapped = passedOptions().query as (to: unknown, context: unknown) => Promise<unknown>
+    const result = await wrapped(to, context)
+
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({ request: mocks.request }), to, context)
+    expect(mocks.request).toHaveBeenCalledWith('read')
+    expect(result).toEqual([{ id: 1 }])
+  })
+
+  it('runs the query inside the nuxt context when available', async () => {
+    mocks.nuxtApp = { runWithContext: vi.fn(fn => fn()) }
+    mocks.request.mockResolvedValueOnce('ok')
+    const { defineDirectusLoader } = await import('../src/runtime/colada/loaders')
+
+    defineDirectusLoader({
+      key: ['posts'],
+      query: (directus: { request: (q: unknown) => Promise<unknown> }) => directus.request('read'),
+    } as never)
+
+    const wrapped = passedOptions().query as (to: unknown, context: unknown) => Promise<unknown>
+    const result = await wrapped({}, {})
+
+    expect(mocks.nuxtApp.runWithContext).toHaveBeenCalledTimes(1)
+    expect(result).toBe('ok')
+  })
+})

--- a/test/colada-queries.test-d.ts
+++ b/test/colada-queries.test-d.ts
@@ -1,0 +1,27 @@
+import type { UseQueryReturn } from '@pinia/colada'
+import { describe, expectTypeOf, it } from 'vitest'
+import { useDirectusItemQuery, useDirectusItemsQuery, useDirectusSingletonQuery } from '../src/runtime/colada/queries'
+
+type TestPost = DirectusSchema['test_posts'][number]
+type TestSettings = DirectusSchema['test_settings']
+
+describe('colada query composable types', () => {
+  it('returns typed collection data', () => {
+    expectTypeOf(useDirectusItemsQuery('test_posts')).toEqualTypeOf<UseQueryReturn<TestPost[]>>()
+  })
+
+  it('returns typed item data', () => {
+    expectTypeOf(useDirectusItemQuery('test_posts', 1)).toEqualTypeOf<UseQueryReturn<TestPost>>()
+  })
+
+  it('returns typed singleton data', () => {
+    expectTypeOf(useDirectusSingletonQuery('test_settings')).toEqualTypeOf<UseQueryReturn<TestSettings>>()
+  })
+
+  it('keeps regular and singleton collections separate', () => {
+    // @ts-expect-error regular collections cannot use the singleton endpoint
+    useDirectusSingletonQuery('test_posts')
+    // @ts-expect-error singleton collections cannot use the list endpoint
+    useDirectusItemsQuery('test_settings')
+  })
+})

--- a/test/colada-queries.test.ts
+++ b/test/colada-queries.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  options: undefined as Record<string, unknown> | undefined,
+  readItem: vi.fn((collection, id, query) => ({ collection, id, query, type: 'item' })),
+  readItems: vi.fn((collection, query) => ({ collection, query, type: 'items' })),
+  readSingleton: vi.fn((collection, query) => ({ collection, query, type: 'singleton' })),
+  request: vi.fn(),
+  useQuery: vi.fn((options) => {
+    mocks.options = options
+    return { data: undefined }
+  }),
+}))
+
+vi.mock('@pinia/colada', () => ({
+  useQuery: mocks.useQuery,
+}))
+
+vi.mock('@directus/sdk', () => ({
+  readItem: mocks.readItem,
+  readItems: mocks.readItems,
+  readSingleton: mocks.readSingleton,
+}))
+
+vi.mock('../src/runtime/composables/directus', () => ({
+  useDirectus: vi.fn(() => ({ request: mocks.request })),
+}))
+
+function currentKey(): unknown {
+  const key = mocks.options?.key
+  return typeof key === 'function' ? key() : key
+}
+
+describe('colada query composables', () => {
+  beforeEach(() => {
+    mocks.options = undefined
+    mocks.readItem.mockClear()
+    mocks.readItems.mockClear()
+    mocks.readSingleton.mockClear()
+    mocks.request.mockReset()
+    mocks.useQuery.mockClear()
+  })
+
+  it('fetches collection items with a deterministic entry key', async () => {
+    mocks.request.mockResolvedValueOnce([{ id: 1, title: 'Post', status: 'published' }])
+    const { useDirectusItemsQuery } = await import('../src/runtime/colada/queries')
+
+    const query = { filter: { status: { _eq: 'published' as const } } }
+    useDirectusItemsQuery('test_posts', { query })
+
+    expect(currentKey()).toEqual(['directus', 'items', 'test_posts', query])
+
+    const result = await (mocks.options?.query as () => Promise<unknown>)()
+    expect(mocks.readItems).toHaveBeenCalledWith('test_posts', query)
+    expect(result).toEqual([{ id: 1, title: 'Post', status: 'published' }])
+  })
+
+  it('keys "no query" as a stable null segment', async () => {
+    const { useDirectusItemsQuery } = await import('../src/runtime/colada/queries')
+
+    useDirectusItemsQuery('test_posts')
+
+    expect(currentKey()).toEqual(['directus', 'items', 'test_posts', null])
+  })
+
+  it('unwraps a reactive id into the key and refetch query', async () => {
+    mocks.request.mockResolvedValueOnce({ id: 7, title: 'Draft', status: 'draft' })
+    const { useDirectusItemQuery } = await import('../src/runtime/colada/queries')
+
+    let id = 7
+    useDirectusItemQuery('test_posts', () => id)
+
+    expect(currentKey()).toEqual(['directus', 'item', 'test_posts', 7, null])
+
+    id = 8
+    expect(currentKey()).toEqual(['directus', 'item', 'test_posts', 8, null])
+
+    await (mocks.options?.query as () => Promise<unknown>)()
+    expect(mocks.readItem).toHaveBeenCalledWith('test_posts', 8, undefined)
+  })
+
+  it('forwards colada options and honours an explicit key', async () => {
+    const { useDirectusSingletonQuery } = await import('../src/runtime/colada/queries')
+
+    useDirectusSingletonQuery('test_settings', { key: ['settings'], staleTime: 60_000 })
+
+    expect(mocks.options?.key).toEqual(['settings'])
+    expect(mocks.options?.staleTime).toBe(60_000)
+
+    mocks.request.mockResolvedValueOnce({ site_name: 'Example' })
+    const result = await (mocks.options?.query as () => Promise<unknown>)()
+    expect(mocks.readSingleton).toHaveBeenCalledWith('test_settings', undefined)
+    expect(result).toEqual({ site_name: 'Example' })
+  })
+})

--- a/test/fixtures/items-schema.d.ts
+++ b/test/fixtures/items-schema.d.ts
@@ -1,0 +1,14 @@
+export {}
+
+declare global {
+  interface DirectusSchema {
+    test_posts: Array<{
+      id: number
+      status: 'draft' | 'published'
+      title: string
+    }>
+    test_settings: {
+      site_name: string
+    }
+  }
+}

--- a/test/items.test-d.ts
+++ b/test/items.test-d.ts
@@ -1,0 +1,27 @@
+import type { AsyncData, NuxtError } from 'nuxt/app'
+import { describe, expectTypeOf, it } from 'vitest'
+import { useDirectusItem, useDirectusItems, useDirectusSingleton } from '../src/runtime/composables/items'
+
+type TestPost = DirectusSchema['test_posts'][number]
+type TestSettings = DirectusSchema['test_settings']
+
+describe('data composable types', () => {
+  it('returns typed collection data', () => {
+    expectTypeOf(useDirectusItems('test_posts')).toEqualTypeOf<AsyncData<TestPost[] | undefined, NuxtError | undefined>>()
+  })
+
+  it('returns typed item data', () => {
+    expectTypeOf(useDirectusItem('test_posts', 1)).toEqualTypeOf<AsyncData<TestPost | undefined, NuxtError | undefined>>()
+  })
+
+  it('returns typed singleton data', () => {
+    expectTypeOf(useDirectusSingleton('test_settings')).toEqualTypeOf<AsyncData<TestSettings | undefined, NuxtError | undefined>>()
+  })
+
+  it('keeps regular and singleton collections separate', () => {
+    // @ts-expect-error regular collections cannot use the singleton endpoint
+    useDirectusSingleton('test_posts')
+    // @ts-expect-error singleton collections cannot use the list endpoint
+    useDirectusItems('test_settings')
+  })
+})

--- a/test/items.test.ts
+++ b/test/items.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  handler: undefined as (() => Promise<unknown>) | undefined,
+  options: undefined as Record<string, unknown> | undefined,
+  readItem: vi.fn((collection, id, query) => ({ collection, id, query, type: 'item' })),
+  readItems: vi.fn((collection, query) => ({ collection, query, type: 'items' })),
+  readSingleton: vi.fn((collection, query) => ({ collection, query, type: 'singleton' })),
+  request: vi.fn(),
+  useAsyncData: vi.fn((key, handler, options) => {
+    mocks.handler = handler
+    mocks.options = options
+    return { key }
+  }),
+}))
+
+vi.mock('#imports', () => ({
+  useAsyncData: mocks.useAsyncData,
+}))
+
+vi.mock('@directus/sdk', () => ({
+  readItem: mocks.readItem,
+  readItems: mocks.readItems,
+  readSingleton: mocks.readSingleton,
+}))
+
+vi.mock('../src/runtime/composables/directus', () => ({
+  useDirectus: vi.fn(() => ({ request: mocks.request })),
+}))
+
+describe('data composables', () => {
+  beforeEach(() => {
+    mocks.handler = undefined
+    mocks.options = undefined
+    mocks.readItem.mockClear()
+    mocks.readItems.mockClear()
+    mocks.readSingleton.mockClear()
+    mocks.request.mockReset()
+    mocks.useAsyncData.mockClear()
+  })
+
+  it('fetches collection items with a deterministic key', async () => {
+    mocks.request.mockResolvedValueOnce([{ id: 1, title: 'Post', status: 'published' }])
+    const { useDirectusItems } = await import('../src/runtime/composables/items')
+
+    useDirectusItems('test_posts', { query: { filter: { status: { _eq: 'published' } } } })
+    const result = await mocks.handler?.()
+
+    expect(mocks.useAsyncData).toHaveBeenCalledWith(
+      'directus:items:test_posts:{"filter":{"status":{"_eq":"published"}}}',
+      expect.any(Function),
+      {},
+    )
+    expect(result).toEqual([{ id: 1, title: 'Post', status: 'published' }])
+  })
+
+  it('fetches one item and forwards AsyncData options', async () => {
+    mocks.request.mockResolvedValueOnce({ id: 7, title: 'Draft', status: 'draft' })
+    const { useDirectusItem } = await import('../src/runtime/composables/items')
+
+    useDirectusItem('test_posts', 7, { immediate: false, key: 'post-7' })
+    await mocks.handler?.()
+
+    expect(mocks.readItem).toHaveBeenCalledWith('test_posts', 7, undefined)
+    expect(mocks.useAsyncData).toHaveBeenCalledWith('post-7', expect.any(Function), { immediate: false })
+  })
+
+  it('uses the singleton SDK command for singleton collections', async () => {
+    mocks.request.mockResolvedValueOnce({ site_name: 'Example' })
+    const { useDirectusSingleton } = await import('../src/runtime/composables/items')
+
+    useDirectusSingleton('test_settings', { query: { fields: ['site_name'] } })
+    const result = await mocks.handler?.()
+
+    expect(mocks.readSingleton).toHaveBeenCalledWith('test_settings', { fields: ['site_name'] })
+    expect(result).toEqual({ site_name: 'Example' })
+  })
+})


### PR DESCRIPTION
### Summary

Adds three layers of typed data fetching on top of the generated `DirectusSchema`, from zero-dependency to router-integrated:

**`useAsyncData` composables (always available)**

`useDirectusItems()`, `useDirectusItem()` and `useDirectusSingleton()` wrap the SDK in Nuxt's native `useAsyncData` with deterministic keys and SSR payload transfer. No extra dependencies.

**Pinia Colada queries (auto-enabled when `@pinia/colada` is installed)**

`useDirectusItemsQuery()`, `useDirectusItemQuery()` and `useDirectusSingletonQuery()` are the same API shape backed by the Colada query cache: one cache entry per key app-wide, `staleTime`/`refetchOn*` control, reactive ids/queries tracked in the entry key, and cache invalidation via `useQueryCache()`. The module registers `@pinia/nuxt`/`@pinia/colada-nuxt` when missing and aliases `@pinia/colada` to a single instance so workspace and layer setups cannot resolve two copies. Opt out with `piniaColada: false`.

**Router data loaders (opt-in, `experimental.dataLoaders`)**

`defineDirectusLoader()` wraps vue-router's experimental `defineColadaLoader()`: loaders run during navigation so page data is ready on first paint, share the Colada cache with the query composables, and can throw (or return a `NavigationResult`) to abort navigation, guaranteeing rendered pages only ever see the data shape the loader returned. The wrapper injects the Directus client and restores the Nuxt context inside loader queries (`tryUseNuxtApp()` finds nothing in a router guard on the server, so the plugin provides the Nuxt app via app-level injection). Scoped under a new `experimental` module option namespace and off by default because the underlying vue-router API is experimental.

### Docs

- New guide: Data Fetching (stable layers)
- New guide under a new Experimental sidebar section: Data Loaders
- Module options reference updated (`piniaColada`, `experimental.dataLoaders`)

### Verification

Verified end to end in the playground against the live demo Directus: SSR first paint contains loader-fetched data, the Colada cache hydrates without a client refetch, and client-side navigation runs loaders with no console errors. Unit tests cover key building, option forwarding, client injection and Nuxt context restoration; type tests pin the schema-driven return types.

### Checklist

- [x] Tests added or updated (new features and bug fixes)
- [x] Playground updated if the feature is user-visible
- [x] Docs updated if behaviour or configuration changed
- [x] Targeting `next` branch (unless this is a hotfix for `main`)
- [x] `pnpm lint` and `pnpm test` pass locally
