### PR TITLE
chore(release): merge v6.1.3 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v6.1.3
+
+[compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.1.2...v6.1.3)
+
+### 🩹 Fixes
+
+- **proxy:** Strip the configured proxy.path instead of a hardcoded /directus prefix ([c53b48a](https://github.com/rolleyio/nuxt-directus-sdk/commit/c53b48a))
+- **devtools:** Embed Directus admin via client URL ([f701560](https://github.com/rolleyio/nuxt-directus-sdk/commit/f701560))
+
+### 🏡 Chore
+
+- Fix README alert syntax, add LICENSE, standardise example URLs ([97d13a7](https://github.com/rolleyio/nuxt-directus-sdk/commit/97d13a7))
+
+### ❤️ Contributors
+
+- Matthew Rollinson <matt@rolley.io>
+
 ## v6.1.2
 
 [compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.1.1...v6.1.2)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Matthew Rollinson <matt@rolley.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export default defineNuxtConfig({
 3. Create a `.env` file:
 
 ```dotenv
-DIRECTUS_URL=https://your-directus-url.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token # Optional: required for type generation
 ```
 
@@ -69,7 +69,7 @@ DIRECTUS_ADMIN_TOKEN=your_admin_token # Optional: required for type generation
 
 That's it! You can now use Directus within your Nuxt app ✨
 
-For cross-domain setups (e.g. `app.example.com` and `api.example.com`), see the [Authentication Guide](https://www.nuxt-directus-sdk.com/guide/authentication.html).
+For cross-domain setups (e.g. `app.example.com` and `directus.example.com`), see the [Authentication Guide](https://www.nuxt-directus-sdk.com/guide/authentication.html).
 
 ## CLI
 
@@ -90,7 +90,8 @@ See the [CLI documentation](https://www.nuxt-directus-sdk.com/api/configuration/
 
 ## Development
 
-> [!IMPORTANT] The playground uses the [directus-template-cli](https://github.com/directus-labs/directus-template-cli?tab=readme-ov-file#applying-a-template) `cms` template.
+> [!IMPORTANT]
+> The playground uses the [directus-template-cli](https://github.com/directus-labs/directus-template-cli?tab=readme-ov-file#applying-a-template) `cms` template.
 > Apply the template with `npx directus-template-cli@latest apply` and follow the interactive prompts.
 
 ```bash

--- a/docs/api/composables/auth.md
+++ b/docs/api/composables/auth.md
@@ -226,7 +226,7 @@ const { inviteUser } = useDirectusAuth()
 await inviteUser(
   'newuser@example.com',
   'role-uuid',
-  'https://yourapp.com/accept-invite'
+  'https://app.example.com/accept-invite'
 )
 ```
 
@@ -261,7 +261,7 @@ const { passwordRequest } = useDirectusAuth()
 
 await passwordRequest(
   'user@example.com',
-  'https://yourapp.com/reset-password'
+  'https://app.example.com/reset-password'
 )
 ```
 

--- a/docs/api/configuration/env.md
+++ b/docs/api/configuration/env.md
@@ -27,13 +27,13 @@ vercel env add DIRECTUS_ADMIN_TOKEN production
 **Netlify:**
 ```bash
 # In Netlify UI: Site settings → Environment variables
-DIRECTUS_URL=https://your-directus.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your-token
 ```
 
 **Docker:**
 ```dockerfile
-ENV DIRECTUS_URL=https://your-directus.com
+ENV DIRECTUS_URL=https://directus.example.com
 ENV DIRECTUS_ADMIN_TOKEN=your-token
 ```
 
@@ -43,7 +43,7 @@ When using Docker Compose, you can use the object URL form in `nuxt.config.ts` t
 export default defineNuxtConfig({
   directus: {
     url: {
-      client: 'https://cms.example.com',
+      client: 'https://directus.example.com',
       server: 'http://directus:8055', // Docker service name
     },
   }

--- a/docs/api/configuration/module.md
+++ b/docs/api/configuration/module.md
@@ -40,7 +40,7 @@ export default defineNuxtConfig({
     // Core configuration — simple string
     url: process.env.DIRECTUS_URL,
     // Or split URLs for Docker/K8s:
-    // url: { client: 'https://cms.example.com', server: 'http://directus:8055' },
+    // url: { client: 'https://directus.example.com', server: 'http://directus:8055' },
     adminToken: process.env.DIRECTUS_ADMIN_TOKEN,
 
     // Development
@@ -96,11 +96,11 @@ Your Directus instance URL. Can be a simple string, or an object with separate `
 export default defineNuxtConfig({
   directus: {
     // Simple string — used everywhere
-    url: 'https://your-directus-instance.com',
+    url: 'https://directus.example.com',
 
     // Or split URLs for Docker/K8s
     url: {
-      client: 'https://cms.example.com', // Browser requests
+      client: 'https://directus.example.com', // Browser requests
       server: 'http://directus:8055', // SSR / server-side requests
     },
   },
@@ -110,7 +110,7 @@ export default defineNuxtConfig({
 Or use environment variable (string form only):
 
 ```dotenv
-DIRECTUS_URL=https://your-directus-instance.com
+DIRECTUS_URL=https://directus.example.com
 ```
 
 ::: tip When to use split URLs

--- a/docs/api/configuration/server.md
+++ b/docs/api/configuration/server.md
@@ -42,7 +42,7 @@ CORS_ORIGIN=http://localhost:3000
 
 ### Cross-Domain Setup
 
-If on different domains (e.g., app.example.com and api.example.com):
+If on different domains (e.g., app.example.com and directus.example.com):
 
 ```dotenv
 # Directus .env

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -55,13 +55,13 @@ For SSO to work with external redirects, you must add your frontend URL to the D
 
 ```dotenv
 # Directus .env
-AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST=https://yourapp.com,http://localhost:3000
+AUTH_<PROVIDER>_REDIRECT_ALLOW_LIST=https://app.example.com,http://localhost:3000
 ```
 
 For example:
 ```dotenv
-AUTH_GOOGLE_REDIRECT_ALLOW_LIST=https://yourapp.com,http://localhost:3000
-AUTH_GITHUB_REDIRECT_ALLOW_LIST=https://yourapp.com,http://localhost:3000
+AUTH_GOOGLE_REDIRECT_ALLOW_LIST=https://app.example.com,http://localhost:3000
+AUTH_GITHUB_REDIRECT_ALLOW_LIST=https://app.example.com,http://localhost:3000
 ```
 
 This is a security setting in Directus to prevent open redirect vulnerabilities.
@@ -111,7 +111,7 @@ const newUser = await register({
 const { passwordRequest, passwordReset } = useDirectusAuth()
 
 // Request password reset
-await passwordRequest('user@example.com', 'https://yourapp.com/reset-password')
+await passwordRequest('user@example.com', 'https://app.example.com/reset-password')
 
 // Reset password with token
 await passwordReset('reset-token', 'new-password')
@@ -122,7 +122,7 @@ For password reset links to work with external domains, you must add them to the
 
 ```dotenv
 # Directus .env
-PASSWORD_RESET_URL_ALLOW_LIST=https://yourapp.com/auth/password-reset,http://localhost:3000/auth/password-reset
+PASSWORD_RESET_URL_ALLOW_LIST=https://app.example.com/auth/password-reset,http://localhost:3000/auth/password-reset
 ```
 
 This is a security setting in Directus to prevent open redirect vulnerabilities when users accept invitations.
@@ -134,7 +134,7 @@ This is a security setting in Directus to prevent open redirect vulnerabilities 
 const { inviteUser, acceptUserInvite } = useDirectusAuth()
 
 // Invite a user
-await inviteUser('newuser@example.com', 'role-id', 'https://yourapp.com/accept-invite')
+await inviteUser('newuser@example.com', 'role-id', 'https://app.example.com/accept-invite')
 
 // Accept invite
 await acceptUserInvite('invite-token', 'password')
@@ -145,7 +145,7 @@ For invite URLs to work with external domains, you must add them to the Directus
 
 ```dotenv
 # Directus .env
-USER_INVITE_URL_ALLOW_LIST=https://yourapp.com/accept-invite,http://localhost:3000/accept-invite
+USER_INVITE_URL_ALLOW_LIST=https://app.example.com/accept-invite,http://localhost:3000/accept-invite
 ```
 
 This is a security setting in Directus to prevent open redirect vulnerabilities when users accept invitations.
@@ -295,7 +295,7 @@ CORS_CREDENTIALS=true
 
 #### Cross-Domain Setup
 
-For production with separate domains (e.g., `app.example.com` and `api.example.com`):
+For production with separate domains (e.g., `app.example.com` and `directus.example.com`):
 
 ```dotenv
 # Directus .env

--- a/docs/guide/server-side.md
+++ b/docs/guide/server-side.md
@@ -562,7 +562,7 @@ Get the full Directus URL for a given path. On the server, this prefers the `ser
 **Example:**
 ```typescript
 const assetsUrl = useDirectusUrl('assets')
-// With simple URL: https://your-directus.com/assets
+// With simple URL: https://directus.example.com/assets
 // With split URL: http://directus:8055/assets (uses internal server URL)
 ```
 

--- a/docs/guide/type-generation.md
+++ b/docs/guide/type-generation.md
@@ -7,7 +7,7 @@ The module generates TypeScript types from your Directus schema at build time, s
 Type generation is enabled by default. Set `DIRECTUS_ADMIN_TOKEN` in your `.env`:
 
 ```dotenv
-DIRECTUS_URL=https://your-directus-instance.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token
 ```
 

--- a/docs/guide/visual-editor.md
+++ b/docs/guide/visual-editor.md
@@ -28,7 +28,7 @@ When `visualEditor: true` is set in your config (the default), the module:
 // nuxt.config.ts
 export default defineNuxtConfig({
   directus: {
-    url: 'https://your-directus-instance.com',
+    url: 'https://directus.example.com',
     visualEditor: true, // This is the default
   },
 })
@@ -305,7 +305,7 @@ const { data: page } = await useAsyncData('page', () =>
 Add `?debug` to any page URL to enable debug logging for the visual editor:
 
 ```
-https://yourapp.com/blog/my-post?debug
+https://app.example.com/blog/my-post?debug
 ```
 
 This outputs detailed logs to the browser console:
@@ -315,7 +315,7 @@ This outputs detailed logs to the browser console:
 [Directus Plugin] Is in iframe: true
 [Directus Visual Editor] Config visualEditor: true
 [Directus Visual Editor] Is in iframe: true
-[Directus Visual Editor] Directus URL: https://your-directus.com
+[Directus Visual Editor] Directus URL: https://directus.example.com
 [Directus Visual Editor] MutationObserver started, waiting for [data-directus] elements
 [Directus Visual Editor] MutationObserver: found 12 [data-directus] elements
 [Directus Visual Editor] Calling apply()...
@@ -424,7 +424,7 @@ const directusVisualEditor = useDirectusVisualEditor()
 
 The `apply()` function uses `postMessage` to handshake with the Directus parent frame. If it returns `false`:
 
-1. **URL mismatch** — The `url` in your nuxt.config must match the exact origin of the Directus admin panel. For example, if your Directus admin is at `https://api.example.com` but your config points to `https://directus.fly.dev`, the handshake will fail
+1. **URL mismatch** — The `url` in your nuxt.config must match the exact origin of the Directus admin panel. For example, if your Directus admin is at `https://directus.example.com` but your config points to `https://directus.fly.dev`, the handshake will fail
 2. **CORS issues** — Ensure your Directus instance allows your Nuxt app origin
 3. **CSP restrictions** — Check that `Content-Security-Policy` allows `frame-ancestors` from your Directus origin
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ export default defineNuxtConfig({
 
 ```dotenv
 # .env
-DIRECTUS_URL=https://your-directus-instance.com
+DIRECTUS_URL=https://directus.example.com
 DIRECTUS_ADMIN_TOKEN=your_admin_token
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-directus-sdk",
   "type": "module",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "packageManager": "pnpm@10.32.1",
   "description": "A Nuxt module for Directus with built-in authentication, realtime, file management, type generation, and visual editor support.",
   "author": "Matthew Rollinson <matt@rolley.io>",

--- a/playground/pages/data/auto-import.vue
+++ b/playground/pages/data/auto-import.vue
@@ -69,7 +69,7 @@ const globals = await directus.request(readSingleton('globals'))</pre>
 
       <pre class="bg-elevated border border-default rounded p-4 text-xs overflow-x-auto mb-3">import { createDirectus, rest, staticToken } from '@directus/sdk'
 
-const publicClient = createDirectus('https://your-directus.example.com')
+const publicClient = createDirectus('https://directus.example.com')
   .with(staticToken('your-static-token'))
   .with(rest())
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -606,7 +606,8 @@ export default defineNuxtModule<ModuleOptions>({
           icon: 'simple-icons:directus',
           view: {
             type: 'iframe',
-            src: useUrl(directusUrl, 'admin'),
+            // Browser must open the public client URL, not an internal Docker/K8s hostname.
+            src: useUrl(clientUrl || directusUrl, 'admin'),
           },
         })
       })

--- a/src/module.ts
+++ b/src/module.ts
@@ -44,8 +44,8 @@ export interface ModuleOptions {
    * Can be a string for a single URL, or an object with `client` and `server` for split URLs.
    * Use the object form in Docker/K8s where SSR needs an internal hostname.
    * @default process.env.DIRECTUS_URL
-   * @example 'https://cms.example.com'
-   * @example { client: 'https://cms.example.com', server: 'http://cms_directus:8055' }
+   * @example 'https://directus.example.com'
+   * @example { client: 'https://directus.example.com', server: 'http://directus:8055' }
    */
   url: DirectusUrl
 

--- a/src/runtime/server/routes/directus-proxy-path.ts
+++ b/src/runtime/server/routes/directus-proxy-path.ts
@@ -1,0 +1,9 @@
+export type ProxyConfig = boolean | { enabled?: boolean, path?: string, wsPath?: string }
+
+export function resolveProxyPath(proxy: ProxyConfig | undefined): string {
+  return (typeof proxy === 'object' && proxy.path) || '/directus'
+}
+
+export function stripProxyPrefix(pathname: string, proxyPath: string): string {
+  return pathname.startsWith(proxyPath) ? pathname.slice(proxyPath.length) : pathname
+}

--- a/src/runtime/server/routes/directus.ts
+++ b/src/runtime/server/routes/directus.ts
@@ -1,16 +1,22 @@
 import { useRuntimeConfig } from '#imports'
 import { defineEventHandler, getRequestIP, getRequestURL, proxyRequest, setResponseHeaders } from 'h3'
 import { joinURL } from 'ufo'
+import type { ProxyConfig } from './directus-proxy-path'
 import { rewriteProxiedSetCookie } from './directus-cookie'
+import { resolveProxyPath, stripProxyPrefix } from './directus-proxy-path'
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig()
   const serverUrl = config.directus?.serverDirectusUrl
   const directusUrl = serverUrl || config.public.directus.directusUrl
 
+  // Strip the configured proxy mount path (not a hardcoded /directus) so
+  // custom `proxy.path` values forward the correct upstream URL.
+  const proxyPath = resolveProxyPath(config.public.directus.proxy as ProxyConfig)
+
   // Get the full URL path with query string
   const url = getRequestURL(event)
-  const path = url.pathname.replace(/^\/directus/, '') + url.search
+  const path = stripProxyPrefix(url.pathname, proxyPath) + url.search
 
   // Whether the request reaching us is HTTPS. We preserve Secure/SameSite=None
   // on HTTPS (production, staging) and downgrade only on HTTP (localhost dev).

--- a/test/proxy-path.test.ts
+++ b/test/proxy-path.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { resolveProxyPath, stripProxyPrefix } from '../src/runtime/server/routes/directus-proxy-path'
+
+describe('resolveProxyPath()', () => {
+  it('returns the configured path when proxy is an object with a path', () => {
+    expect(resolveProxyPath({ enabled: true, path: '/_content' })).toBe('/_content')
+  })
+
+  it('falls back to /directus when proxy is an object without a path', () => {
+    expect(resolveProxyPath({ enabled: true })).toBe('/directus')
+  })
+
+  it('falls back to /directus when proxy is a boolean', () => {
+    expect(resolveProxyPath(true)).toBe('/directus')
+    expect(resolveProxyPath(false)).toBe('/directus')
+  })
+
+  it('falls back to /directus when proxy is undefined', () => {
+    expect(resolveProxyPath(undefined)).toBe('/directus')
+  })
+})
+
+describe('stripProxyPrefix()', () => {
+  it('strips the default /directus prefix', () => {
+    expect(stripProxyPrefix('/directus/items/posts', '/directus')).toBe('/items/posts')
+  })
+
+  // Regression test for #102: a custom proxy.path was mounted correctly but
+  // never stripped, so the wrong URL was forwarded upstream.
+  it('strips a custom proxy path', () => {
+    expect(stripProxyPrefix('/_content/items/posts', '/_content')).toBe('/items/posts')
+  })
+
+  it('returns an empty path when the request hits the mount root', () => {
+    expect(stripProxyPrefix('/directus', '/directus')).toBe('')
+  })
+
+  it('leaves the pathname untouched when it does not start with the proxy path', () => {
+    expect(stripProxyPrefix('/other/items/posts', '/directus')).toBe('/other/items/posts')
+  })
+})


### PR DESCRIPTION
Syncs the v6.1.3 release into main:

- Merges next (fix(proxy) #103, fix(devtools) #112, housekeeping #104) into main
- Adds the `chore(release): v6.1.3` commit (version bump and curated changelog)

The changelog entry was curated by hand this time: cutting from main meant the v6.1.2..v6.1.3 range picked up already-released 5.0.x commits that are reachable from main but not from the v6.1.2 tag. Once this PR lands, the v6.1.3 tag reaches all of main's history, so future releases from main generate clean changelogs automatically.

Merge with a merge commit (not squash) so the tagged release commit stays reachable from main.
