### PR TITLE
chore(ci): automate releases with uppt release PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@
 - [ ] Tests added or updated (new features and bug fixes)
 - [ ] Playground updated if the feature is user-visible
 - [ ] Docs updated if behaviour or configuration changed
-- [ ] Targeting `next` branch (unless this is a hotfix for `main`)
+- [ ] PR title follows conventional commits (it becomes the changelog entry on release)
 - [ ] `pnpm lint` and `pnpm test` pass locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, next]
+    branches: [main]
   push:
-    branches: [main, next]
-  workflow_call:
+    branches: [main]
 
 jobs:
   ci:

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -3,7 +3,7 @@ name: Preview packages (pkg.pr.new)
 on:
   pull_request:
   push:
-    branches: [next]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,59 +2,103 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
+  pull_request:
+    types: [closed]
+    branches: [main]
+  # this is required to trigger releases when the release PR is merged, or to rerun a release if needed
+  workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write
+permissions: {}
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-
-  release:
-    needs: ci
+  # Parse commits since the last tag, push a `release/vX.Y.Z` branch, open
+  # or update a draft release PR, and close any superseded release PRs
+  # (e.g. `release/v6.1.4` when the bump is now `release/v6.2.0`).
+  pr:
+    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # push the `release/vX.Y.Z` branch and delete superseded ones
+      pull-requests: write  # create a release PR, update its body, close superseded PRs
+    steps:
+      - uses: danielroe/uppt/pr@7bcfb5397c37202ef882363f755423130419d28a # v0.5.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The release PR was merged: tag the squash commit, cut a GitHub release
+  # from the PR body, and dispatch the publish workflow. The `release/v`
+  # head-ref guard keeps regular feature-PR merges from triggering this;
+  # the head-repo guard keeps merged fork PRs from triggering it.
+  release:
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.head.ref, 'release/v')
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write       # push the `vX.Y.Z` tag and create the GitHub release
+      actions: write        # `gh workflow run release.yml --ref vX.Y.Z` chained dispatch
+    steps:
+      - uses: danielroe/uppt/release@7bcfb5397c37202ef882363f755423130419d28a # v0.5.5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  # The chained dispatch from `release` lands here as a `workflow_dispatch`
+  # event on a `vX.Y.Z` tag ref. Checkout, install, and playground prepare
+  # are handled here (checkout/install disabled on uppt/pack) because
+  # nuxt-module-build extends playground/.nuxt/tsconfig.json, so `prepack`
+  # fails without `dev:prepare` having run first. Manual recovery uses the
+  # same path (Run workflow -> pick a `v*` tag).
+  pack:
+    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pack-${{ github.ref }}
+      cancel-in-progress: false
+    permissions: {}
+    outputs:
+      files: ${{ steps.pack.outputs.files }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
-      # Node 24 ships with npm 11.x, which is required for Trusted Publishing
-      # OIDC handshake. Node 22 ships npm 10.x; self-upgrading it in CI hits
-      # a reify-finish bug. Matches nuxt/image's release pattern.
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 
-      # Required before publish — nuxt-module-build (invoked by npm's prepack
-      # lifecycle hook during publish) extends playground/.nuxt/tsconfig.json
       - run: pnpm run dev:prepare
 
-      - name: Determine npm tag
-        id: npm-tag
-        run: |
-          # Any tag containing a hyphen after the version (e.g. v6.0.0-0,
-          # v6.0.0-beta.1, v6.0.0-rc.2) is a prerelease → publish under `next`.
-          # Clean semver tags (e.g. v6.0.0) → publish under `latest`.
-          case "${{ github.ref_name }}" in
-            *-*) echo "tag=next" >> "$GITHUB_OUTPUT" ;;
-            *) echo "tag=latest" >> "$GITHUB_OUTPUT" ;;
-          esac
+      - id: pack
+        uses: danielroe/uppt/pack@7bcfb5397c37202ef882363f755423130419d28a # v0.5.5
+        with:
+          checkout: false
+          install: false
 
-      # Publish with npm (not pnpm) — pnpm's OIDC support is incomplete
-      # (see pnpm/pnpm#9812). Auth is via npm Trusted Publishing.
-      - name: Publish to npm
-        run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
-
-      - name: Create GitHub Release
-        run: npx changelogithub
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # `publish` downloads the prebuilt tarball from the pack job's artifact
+  # and stages it for publish on npm (approve on npmjs.com to go live).
+  publish:
+    if: |
+      github.event_name == 'workflow_dispatch'
+      && startsWith(github.ref, 'refs/tags/v')
+      && needs.pack.outputs.files != '[]'
+    needs: pack
+    runs-on: ubuntu-latest
+    concurrency:
+      group: publish-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      id-token: write       # OIDC claim for npm trusted publisher
+    environment: npm        # must match the trusted-publisher entry on npmjs.com
+    steps:
+      - uses: danielroe/uppt/publish@7bcfb5397c37202ef882363f755423130419d28a # v0.5.5
+        with:
+          files: ${{ needs.pack.outputs.files }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+> [!NOTE]
+> This file is frozen as of v6.1.3. Release notes for newer versions live on [GitHub Releases](https://github.com/rolleyio/nuxt-directus-sdk/releases).
+
 ## v6.1.3
 
 [compare changes](https://github.com/rolleyio/nuxt-directus-sdk/compare/v6.1.2...v6.1.3)

--- a/README.md
+++ b/README.md
@@ -116,14 +116,13 @@ pnpm run lint
 # Run Vitest
 pnpm run test
 pnpm run test:watch
-
-# Release new version (see RELEASING.md)
-pnpm run release
 ```
+
+Releases are automated; merging the open release PR cuts a release (see [RELEASING.md](./RELEASING.md)).
 
 ## Contributing
 
-Contributions are welcome. Please target the `next` branch for new features and fixes; `main` is reserved for stable releases and hotfixes. See [RELEASING.md](./RELEASING.md) for the release process.
+Contributions are welcome. Please target the `main` branch; every pull request gets an installable preview package via pkg.pr.new. See [RELEASING.md](./RELEASING.md) for the release process.
 
 <!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/nuxt-directus-sdk/latest.svg?style=flat&colorA=18181B&colorB=28CF8D

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,57 +1,35 @@
 # Releasing
 
-## Cutting a release
+Releases are automated with [uppt](https://github.com/danielroe/uppt), the same flow used by nuxt/nuxt and nuxt/image. Nobody releases from a laptop and no npm tokens exist.
 
-From `main`, with a clean working tree:
+## The release cycle
 
-```bash
-pnpm release
-```
+1. **Merge PRs into `main`.** Every squash commit's title is a conventional commit; that is what drives version bumps and changelog entries. Every PR also gets an installable preview package via pkg.pr.new for testing before merge.
+2. **A draft release PR appears automatically.** On every push to `main`, `uppt/pr` parses commits since the last tag, picks the bump (a `fix:` opens `release/v6.1.4`, a later `feat:` supersedes it with `release/v6.2.0`), and opens or updates a release PR containing only the `package.json` version bump. Its body is the generated changelog.
+3. **Curate the release PR.** Edit the body freely: anything above the `## 👉 Changelog` heading is preserved when the changelog regenerates, so put highlights, timetables, or TODO checklists there. The body becomes the GitHub release notes verbatim.
+4. **Merge the release PR to cut the release.** `uppt/release` tags the squash commit, creates the GitHub release from the PR body, and dispatches the publish jobs on the tag.
+5. **Approve the staged publish.** `uppt/pack` builds the tarball (see build notes below) and `uppt/publish` stages it on npm via OIDC trusted publishing. Approve it on npmjs.com (requires 2FA) and the version goes live.
 
-That runs lint + tests + build, then invokes `changelogen --release --push --no-github`, which:
+The changelog lives in GitHub Releases from v6.1.3 onward; `CHANGELOG.md` is frozen.
 
-1. Bumps `package.json` version based on conventional-commit history.
-2. Writes `CHANGELOG.md`.
-3. Commits both changes.
-4. Tags the commit (e.g. `v5.1.0`).
-5. Pushes the commit and tag to the current branch.
+## Build notes
 
-The pushed tag fires `.github/workflows/release.yml`, which re-runs CI (via `workflow_call` on `ci.yml`) and, if it passes, publishes to npm and creates the GitHub Release via `changelogithub`.
+`prepack` (`nuxt-module-build build`) extends `playground/.nuxt/tsconfig.json`, so the playground must be prepared before packing. The `pack` job therefore handles checkout and install itself (`checkout: false`, `install: false` on `uppt/pack`) and runs `pnpm run dev:prepare` before the pack step. The pkg.pr.new workflow does the same.
 
-### Node versions
+## Prereleases
 
-- **CI** runs on Node `lts/jod` (v22) — matches Nuxt's LTS floor, which is what end users run against.
-- **Release** runs on Node `lts/krypton` (v24) — required for npm Trusted Publishing's OIDC handshake (needs npm 11, which ships with Node 24). CI passing on LTS gates whether release runs at all.
+uppt has no prerelease channel yet. When the next major needs betas, cut them manually from the major branch (e.g. `v7`): bump the version to `7.0.0-beta.N`, tag it, build with `pnpm run dev:prepare && pnpm run prepack`, and `npm publish --tag next` with a 2FA login. Revisit if uppt grows prerelease support.
 
-### Prereleases
+## One-off configuration this flow depends on
 
-From `next`, with a clean working tree:
-
-```bash
-pnpm release:next
-```
-
-Adds `--prerelease` to `changelogen` (producing tags like `v5.1.0-beta.0`) and the CI workflow publishes under the `next` npm dist-tag. The changelog on `next` stays on `next` — `main`'s changelog is not touched.
-
-### Which branch owns what
-
-- `main` is the source of truth for stable releases. `CHANGELOG.md` on `main` reflects stable history only.
-- `next` cuts prereleases. Its `CHANGELOG.md` evolves independently and never writes back to `main`.
-- When `next` work is ready to ship stable, merge `next` → `main` and run `pnpm release` from `main`. The stable changelog entry is generated from commits that landed on `main`.
-
-### Authentication
-
-Publishing uses **npm Trusted Publishing** (OIDC) — no `NPM_TOKEN` secret stored in the repo. The OIDC token is granted by the `id-token: write` permission in `release.yml`, and the npmjs.com package is configured with `rolleyio/nuxt-directus-sdk` + `release.yml` as a Trusted Publisher.
-
-If the Trusted Publishing config on npmjs.com ever gets removed or the workflow filename changes, publish will fail with a 403. Re-add the repo as a Trusted Publisher on the package's Access page.
-
-### Repo settings that matter
-
-- Squash-merge only, with "default commit message = pull request title" — `changelogen` reads conventional commits from the PR title that lands on the release branch.
-- Branch protection on `main` should allow tag creation; no direct pushes are needed for releases (the tag is pushed from your laptop by `pnpm release`).
+- **npm trusted publisher** on the package's Access page: repo `rolleyio/nuxt-directus-sdk`, workflow `release.yml`, environment `npm`, with the `npm stage publish` permission. Staged publishing means every release needs a manual approval on npmjs.com before it goes live.
+- **GitHub environment `npm`**, matching the trusted publisher entry (scoped to `v*` tags).
+- **Allow GitHub Actions to create and approve pull requests** under Settings, Actions, General. Without it, `uppt/pr` fails with 403 when opening the release PR.
+- **Squash merge with PR title as the commit message**, so conventional PR titles land on `main`.
 
 ## Troubleshooting
 
-- **Tag already exists** — `changelogen` bumped but the push failed. Inspect with `git tag` and delete locally (`git tag -d vX.Y.Z`) if you need to retry. Avoid force-pushing tags that have already hit the remote.
-- **Publish workflow ran but no npm release** — check the workflow run; `npm publish` can fail silently if provenance can't be signed. Requires Node 22.14+ and `id-token: write` permissions (both configured).
-- **`ERR_PNPM_OUTDATED_LOCKFILE`** — the lockfile drifted from `package.json`. Run `pnpm install` locally, commit `pnpm-lock.yaml`, push.
+- **Publish failed or was never staged.** Re-run the publish path manually: Actions, Release, Run workflow, pick the `vX.Y.Z` tag. `pack` and `publish` are idempotent from a tag.
+- **`uppt/pr` 403 when opening the release PR.** The "allow Actions to create pull requests" setting was turned off; re-enable it.
+- **Trusted publishing 403 on publish.** The trusted publisher entry on npmjs.com was removed or the workflow filename or environment name changed. Re-add it on the package's Access page.
+- **Wrong version in the release PR.** Check the commit titles on `main` since the last tag; the bump is derived from them. Fix by landing a correctly-typed commit; the PR updates on the next push.

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "dev": "pnpm run dev:prepare && nuxt dev playground",
     "dev:build": "nuxt build playground",
     "dev:prepare": "nuxt-module-build build --stub && nuxt prepare playground",
-    "release": "pnpm run lint && pnpm run test && pnpm run prepack && changelogen --release --push --no-github",
-    "release:next": "pnpm run lint && pnpm run test && pnpm run prepack && changelogen --release --prerelease beta --push --no-github",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "vitest run",


### PR DESCRIPTION
Replaces the laptop-driven changelogen release flow with [uppt](https://github.com/danielroe/uppt), the release automation used by nuxt/nuxt and nuxt/image, and retires the `next` branch model in favour of trunk-based development.

## What changes

- `release.yml` now implements the uppt flow: every push to `main` opens or updates a draft release PR; merging it tags the squash commit, creates the GitHub release from the PR body, and stages an npm publish via OIDC trusted publishing. The `pack` job handles checkout and install itself because `prepack` needs `pnpm run dev:prepare` first (same as the pkg.pr.new workflow).
- `ci.yml` and `pkg-pr-new.yml` drop their `next` triggers; previews now build on PRs and pushes to `main`.
- `release`/`release:next` scripts removed from `package.json`.
- RELEASING.md rewritten for the new flow; CHANGELOG.md frozen at v6.1.3 (release notes live on GitHub Releases from here on).
- README and PR template updated: PRs target `main`.

## Follow-ups after merge

- Retarget open PRs #105-#111 and #115 from `next` to `main`, then delete the `next` branch.
- Update the npm trusted publisher entry (environment `npm`, `npm stage publish` permission).
- The GitHub `npm` environment (scoped to `v*` tags) and the "allow Actions to create PRs" setting are already in place.

Prereleases for v7 stay manual for now; see RELEASING.md.
