### PR TITLE
chore(ci): install with --ignore-scripts in the release pack job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,9 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      # --ignore-scripts matches uppt's own install hardening: no dependency
+      # lifecycle scripts run on the runner that builds the publish tarball
+      - run: pnpm install --frozen-lockfile --ignore-scripts
 
       - run: pnpm run dev:prepare
 


### PR DESCRIPTION
Matches uppt's own install hardening in the pack job: dependency lifecycle scripts no longer run on the runner that builds the publish tarball, so a compromised transitive dependency cannot execute code there.

Verified locally from a cold clone: `pnpm install --frozen-lockfile --ignore-scripts` followed by `pnpm run dev:prepare` and `pnpm pack` builds successfully and produces a tarball with the same 60 files as the published 6.1.3.
